### PR TITLE
Update shebang to use python2

### DIFF
--- a/bin/asciiio.py
+++ b/bin/asciiio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import os


### PR DESCRIPTION
On archlinux the default `python` is python 3, so I get something like `print: invalid syntax` when running `asciiio`.  I'm told the command `python2` is valid on systems where `python` points to python 2.  Thanks to the fine folks in #archlinux!
