### PR TITLE
Allow access to curl through a squid proxy

### DIFF
--- a/bin/asciiio
+++ b/bin/asciiio
@@ -316,7 +316,7 @@ class Uploader(object):
 
         fields = ["-F asciicast[%s]=@%s/%s" % (f, self.path, files[f]) for f in files]
 
-        cmd = "curl -sSf -o - %s %s" % (' '.join(fields), '%s/api/asciicasts' % self.api_url)
+        cmd = "curl -sSf -H\"Expect:\" -o - %s %s" % (' '.join(fields), '%s/api/asciicasts' % self.api_url)
 
         process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)


### PR DESCRIPTION
The squid proxy denies 100 continue expectation (http://www.squid-cache.org/Doc/config/ignore_expect_100/). And this header is added by default by curl. Adding a -H"Expect:" to the curl cmd in uploader solves this.
