### PR TITLE
asciiio: utilize high resolution monotonic clock when available

### DIFF
--- a/bin/asciiio
+++ b/bin/asciiio
@@ -25,6 +25,35 @@ import StringIO
 SCRIPT_NAME = os.path.basename(sys.argv[0])
 BASE_DIR = os.path.expanduser("~/.ascii.io")
 
+import ctypes
+
+CLOCK_MONOTONIC = 1
+
+class timespec(ctypes.Structure):
+    _fields_ = [
+        ('tv_sec', ctypes.c_long),
+        ('tv_nsec', ctypes.c_long)
+    ]
+
+try:
+    librt = ctypes.CDLL('librt.so.1', use_errno=True)
+    clock_gettime = librt.clock_gettime
+    clock_gettime.argtypes = [ctypes.c_int, ctypes.POINTER(timespec)]
+except OSError:
+    clock_gettime = None
+
+def monotonic_time():
+    # Attempt to use a high-resolution monotonic clock. Failing that, fall back
+    # to Python's time.time().
+    if clock_gettime:
+        t = timespec()
+        if clock_gettime(CLOCK_MONOTONIC, ctypes.pointer(t)) != 0:
+            errno_ = ctypes.get_errno()
+            raise OSError(errno_, os.strerror(errno_))
+        return t.tv_sec + t.tv_nsec * 1e-9
+
+    else:
+        return time.time()
 
 class AsciiCast(object):
     QUEUE_DIR = BASE_DIR + "/queue"
@@ -56,10 +85,10 @@ class AsciiCast(object):
 
     def _record(self):
         os.makedirs(self.path)
-        self.recording_start = time.time()
+        self.recording_start = monotonic_time()
         command = self.command or os.environ['SHELL'].split()
         PtyRecorder(self.path, command, self.record_input).run()
-        self.duration = time.time() - self.recording_start
+        self.duration = monotonic_time() - self.recording_start
         self._save_metadata()
 
     def _save_metadata(self):
@@ -122,11 +151,11 @@ class TimedFile(object):
         self.data_file = StringIO.StringIO()
         self.time_file = StringIO.StringIO()
 
-        self.old_time = time.time()
+        self.old_time = monotonic_time()
 
     def write(self, data):
         self.data_file.write(data)
-        now = time.time()
+        now = monotonic_time()
         delta = now - self.old_time
         self.time_file.write("%f %d\n" % (delta, len(data)))
         self.old_time = now


### PR DESCRIPTION
time.time()'s resolution (despite its precision) is documented to be at
1-second granularity, which is terrible for something like screencasting:

http://docs.python.org/2/library/time.html#time.time

If we were using Python 3.x, we could just use time.monotonic() and be done
with it, but we're in a largely Python 2.x world right now. For now, let's use
ctypes to load up and use clock_gettime and gettimeofday.

clock_gettime(CLOCK_MONOTONIC,...) exemplifies all the attributes we care about
for this particular use case: it's monotonically increasing, it's high
precision, and it's high resolution. This makes it ideal for determining
timespans.

gettimeofday() is a good alternative, and more widely implemented (e.g. on BSD
and such). It's both high precision and high resolution, but it is _not_
monotonically increasing. It's subject to things like NTP adjustments, which
causes it to sometimes jump backwards or forwards by arbitrary amounts. It's
not ideal, but the higher resolution is a desirable trait.

Signed-off-by: Steven Noonan steven@uplinklabs.net
