### PR TITLE
Issue #36 fix. Specify extension for sed -i flag to fix python2 path issue on OSX

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -32,7 +32,7 @@ fi
 $SUDO curl -skL $BIN_URL -o $TARGET
 
 if [ ! $(which python2 2>/dev/null) ]; then
-  $SUDO sed -i '1 s/python2/python/' $TARGET
+  $SUDO sed -i '.orig' '1 s/python2/python/' $TARGET
 fi
 
 if [[ $? == 0 ]]; then


### PR DESCRIPTION
I finally got asciinema running on my Macbook Air. 

This is a fix for issue #36, where the sed statement to correct python2 to python fails on OS X. It is a small fix. The sed -i flag simply needs to have an extension specified. 
