### PR TITLE
Fix issue with 'sed' command on Mac OS X.

### DIFF
--- a/install
+++ b/install
@@ -32,7 +32,11 @@ fi
 $SUDO curl -skL $BIN_URL -o $TARGET
 
 if [ ! $(which python2 2>/dev/null) ]; then
-  $SUDO sed -i '1 s/python2/python/' $TARGET
+  if [ $(uname) == 'Darwin' ]; then
+    $SUDO sed -i '' '1 s/python2/python/' $TARGET
+  else
+    $SUDO sed -i '1 s/python2/python/' $TARGET
+  fi
 fi
 
 if [[ $? == 0 ]]; then


### PR DESCRIPTION
When running the script on Mac OS X, the sed command expects a parameter with the -i flag that specifies the backup extension. In this case, no backup is needed, so it can be a blank string.

The following is the error:

```
Installing to /usr/local/bin/asciinema...
sed: 1: "/usr/local/bin/asciinema": extra characters at the end of l command
Oopsie, something unexpected happened.
```

The following article explains the issue in depth:
[sed in-place editing (-i) difference on Mac OS X](http://blog.mpdaugherty.com/2010/05/27/difference-with-sed-in-place-editing-on-mac-os-x-vs-linux/)

This fixes #36.
