### PR TITLE
Set default terminal size (80x24) for non-interactive mode

### DIFF
--- a/asciinema/pty_recorder.py
+++ b/asciinema/pty_recorder.py
@@ -26,9 +26,13 @@ class PtyRecorder(object):
             '''
 
             # Get the terminal size of the real terminal, set it on the pseudoterminal.
-            buf = array.array('h', [0, 0, 0, 0])
-            fcntl.ioctl(pty.STDOUT_FILENO, termios.TIOCGWINSZ, buf, True)
-            fcntl.ioctl(master_fd, termios.TIOCSWINSZ, buf)
+            if os.isatty(pty.STDOUT_FILENO):
+                buf = array.array('h', [0, 0, 0, 0])
+                fcntl.ioctl(pty.STDOUT_FILENO, termios.TIOCGWINSZ, buf, True)
+                fcntl.ioctl(master_fd, termios.TIOCSWINSZ, buf)
+            else:
+                buf = array.array('h', [24, 80, 0, 0])
+                fcntl.ioctl(master_fd, termios.TIOCSWINSZ, buf)
 
         def _signal_winch(signal, frame):
             '''Signal handler for SIGWINCH - window size has changed.'''


### PR DESCRIPTION
Simple solution for issue #51. Just identify if we are in interactive or non-interactive terminal. If not, we want to setup default terminal size - I use 80 columns x 24 rows which should be supported by everything.
