### PR TITLE
Fix download badge to link to asciinema

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/asciinema.png)](http://badge.fury.io/py/asciinema)
 [![Build Status](https://travis-ci.org/sickill/asciinema.png?branch=master)](https://travis-ci.org/sickill/asciinema)
-[![Downloads](https://pypip.in/d/asciinema/badge.png)](https://crate.io/packages/requests/)
+[![Downloads](https://pypip.in/d/asciinema/badge.png)](https://pypi.python.org/pypi/asciinema)
 
 Command line client for [asciinema.org](https://asciinema.org) service.
 


### PR DESCRIPTION
Was previously pointing at the requests page. Also move it away from crate.io which just redirects now.
