### PR TITLE
Add option -n to skip and deny upload confirmation

### DIFF
--- a/asciinema/commands/builder.py
+++ b/asciinema/commands/builder.py
@@ -9,7 +9,7 @@ from .version import VersionCommand
 
 def get_command(argv, config):
     try:
-        opts, commands = getopt.getopt(argv, 'c:t:ihvy', ['help', 'version'])
+        opts, commands = getopt.getopt(argv, 'c:t:ihvyn', ['help', 'version'])
     except getopt.error as msg:
         return ErrorCommand(msg)
 
@@ -24,6 +24,7 @@ def get_command(argv, config):
     cmd = None
     title = None
     skip_confirmation = False
+    do_not_upload = False
 
     for opt, arg in opts:
         if opt in ('-h', '--help'):
@@ -36,10 +37,12 @@ def get_command(argv, config):
             title = arg
         elif opt == '-y':
             skip_confirmation = True
+        elif opt == '-n':
+            do_not_upload = True
 
     if command == 'rec':
         return RecordCommand(config.api_url, config.api_token, cmd, title,
-                             skip_confirmation)
+                             skip_confirmation, do_not_upload)
     elif command == 'auth':
         return AuthCommand(config.api_url, config.api_token)
 

--- a/asciinema/commands/help.py
+++ b/asciinema/commands/help.py
@@ -15,6 +15,7 @@ Actions:
 Optional arguments:
  -c command       run specified command instead of shell ($SHELL)
  -t title         specify title of recorded asciicast
- -y               don't prompt for confirmation
+ -y               don't prompt for confirmation and upload
+ -n               don't prompt for confirmation and don't upload
  -h, --help       show this help message and exit
  -v, --version    show version information'''

--- a/asciinema/commands/record.py
+++ b/asciinema/commands/record.py
@@ -9,12 +9,13 @@ from asciinema.confirmator import Confirmator
 class RecordCommand(object):
 
     def __init__(self, api_url, api_token, cmd, title, skip_confirmation,
-                 recorder=None, uploader=None, confirmator=None):
+                 do_not_upload, recorder=None, uploader=None, confirmator=None):
         self.api_url = api_url
         self.api_token = api_token
         self.cmd = cmd
         self.title = title
         self.skip_confirmation = skip_confirmation
+        self.do_not_upload = do_not_upload
         self.recorder = recorder if recorder is not None else Recorder()
         self.uploader = uploader if uploader is not None else Uploader()
         self.confirmator = confirmator if confirmator is not None else Confirmator()
@@ -53,6 +54,8 @@ class RecordCommand(object):
                 sys.exit(1)
 
     def _upload_confirmed(self):
+        if self.do_not_upload:
+            return False
         if self.skip_confirmation:
             return True
 

--- a/tests/builder_test.py
+++ b/tests/builder_test.py
@@ -36,6 +36,7 @@ class TestGetCommand(object):
         assert_equal(None, command.cmd)
         assert_equal(None, command.title)
         assert_equal(False, command.skip_confirmation)
+        assert_equal(False, command.do_not_upload)
 
     def test_get_command_when_cmd_is_rec_and_options_given(self):
         argv = ['-c', '/bin/bash -l', '-t', "O'HAI LOL", '-y', 'rec']
@@ -47,6 +48,15 @@ class TestGetCommand(object):
         assert_equal('/bin/bash -l', command.cmd)
         assert_equal("O'HAI LOL", command.title)
         assert_equal(True, command.skip_confirmation)
+        assert_equal(False, command.do_not_upload)
+
+    def test_get_command_when_cmd_is_do_not_upload(self):
+        argv = ['-n', 'rec']
+        command = get_command(argv, self.config)
+
+        assert_equal(RecordCommand, type(command))
+        assert_equal(False, command.skip_confirmation)
+        assert_equal(True, command.do_not_upload)
 
     def test_get_command_when_cmd_is_auth(self):
         command = get_command(['auth'], self.config)

--- a/tests/record_command_test.py
+++ b/tests/record_command_test.py
@@ -57,7 +57,7 @@ class TestRecordCommand(Test):
 
     def create_command(self, skip_confirmation):
         return RecordCommand('http://the/url', 'a1b2c3', 'ls -l', 'the title',
-                             skip_confirmation, self.recorder, self.uploader,
+                             skip_confirmation, False, self.recorder, self.uploader,
                              self.confirmator)
 
     def test_execute_when_upload_confirmation_skipped(self):


### PR DESCRIPTION
Hey,

there is already an option `-y` for skipping confirmation for the upload. However I would like to have it skip the confirmation and not upload the video. I thought the intuitive way for it would be adding a `-n` option. 

This is my suggestion there, would be nice to have it merged, if you are fine with it.

Best,
juliaguar
