### PR TITLE
Simple patch to enable max-wait for playback

### DIFF
--- a/asciicast/player.go
+++ b/asciicast/player.go
@@ -1,13 +1,14 @@
 package asciicast
 
 import (
+	"math"
 	"time"
 
 	"github.com/asciinema/asciinema/terminal"
 )
 
 type Player interface {
-	Play(string) error
+	Play(string, float64) error
 }
 
 type AsciicastPlayer struct {
@@ -18,14 +19,14 @@ func NewPlayer() Player {
 	return &AsciicastPlayer{Terminal: terminal.NewTerminal()}
 }
 
-func (r *AsciicastPlayer) Play(path string) error {
+func (r *AsciicastPlayer) Play(path string, maxWait float64) error {
 	asciicast, err := Load(path)
 	if err != nil {
 		return err
 	}
 
 	for _, frame := range asciicast.Stdout {
-		delay := time.Duration(float64(time.Second) * frame.Delay)
+		delay := time.Duration(float64(time.Second) * math.Min(maxWait, frame.Delay))
 		time.Sleep(delay)
 		r.Terminal.Write(frame.Data)
 	}

--- a/asciicast/player.go
+++ b/asciicast/player.go
@@ -6,8 +6,6 @@ import (
 	"github.com/asciinema/asciinema/terminal"
 )
 
-const playbackDefaultMaxWait = 3600.0
-
 type Player interface {
 	Play(string, uint) error
 }

--- a/asciicast/player.go
+++ b/asciicast/player.go
@@ -31,7 +31,7 @@ func (r *AsciicastPlayer) Play(path string, maxWait uint) error {
 	if adjustedMaxWait <= 0 {
 		adjustedMaxWait = playbackDefaultMaxWait
 	}
-	
+
 	for _, frame := range asciicast.Stdout {
 		delay := time.Duration(float64(time.Second) * math.Min(adjustedMaxWait, frame.Delay))
 		time.Sleep(delay)

--- a/asciicast/player.go
+++ b/asciicast/player.go
@@ -7,8 +7,10 @@ import (
 	"github.com/asciinema/asciinema/terminal"
 )
 
+const playbackDefaultMaxWait = 3600.0
+
 type Player interface {
-	Play(string, float64) error
+	Play(string, uint) error
 }
 
 type AsciicastPlayer struct {
@@ -19,14 +21,19 @@ func NewPlayer() Player {
 	return &AsciicastPlayer{Terminal: terminal.NewTerminal()}
 }
 
-func (r *AsciicastPlayer) Play(path string, maxWait float64) error {
+func (r *AsciicastPlayer) Play(path string, maxWait uint) error {
 	asciicast, err := Load(path)
 	if err != nil {
 		return err
 	}
 
+	adjustedMaxWait := float64(maxWait)
+	if adjustedMaxWait <= 0 {
+		adjustedMaxWait = playbackDefaultMaxWait
+	}
+	
 	for _, frame := range asciicast.Stdout {
-		delay := time.Duration(float64(time.Second) * math.Min(maxWait, frame.Delay))
+		delay := time.Duration(float64(time.Second) * math.Min(adjustedMaxWait, frame.Delay))
 		time.Sleep(delay)
 		r.Terminal.Write(frame.Data)
 	}

--- a/asciicast/player.go
+++ b/asciicast/player.go
@@ -1,7 +1,6 @@
 package asciicast
 
 import (
-	"math"
 	"time"
 
 	"github.com/asciinema/asciinema/terminal"
@@ -27,14 +26,12 @@ func (r *AsciicastPlayer) Play(path string, maxWait uint) error {
 		return err
 	}
 
-	adjustedMaxWait := float64(maxWait)
-	if adjustedMaxWait <= 0 {
-		adjustedMaxWait = playbackDefaultMaxWait
-	}
-
 	for _, frame := range asciicast.Stdout {
-		delay := time.Duration(float64(time.Second) * math.Min(adjustedMaxWait, frame.Delay))
-		time.Sleep(delay)
+		delay := frame.Delay
+		if maxWait > 0 && delay > float64(maxWait) {
+			delay = float64(maxWait)
+		}
+		time.Sleep(time.Duration(float64(time.Second) * delay))
 		r.Terminal.Write(frame.Data)
 	}
 

--- a/commands/play.go
+++ b/commands/play.go
@@ -13,5 +13,5 @@ func NewPlayCommand() *PlayCommand {
 }
 
 func (c *PlayCommand) Execute(filename string, maxWait uint) error {
-	return c.Player.Play(filename, float64(maxWait))
+	return c.Player.Play(filename, maxWait)
 }

--- a/commands/play.go
+++ b/commands/play.go
@@ -12,6 +12,6 @@ func NewPlayCommand() *PlayCommand {
 	}
 }
 
-func (c *PlayCommand) Execute(filename string) error {
-	return c.Player.Play(filename)
+func (c *PlayCommand) Execute(filename string, maxWait uint) error {
+	return c.Player.Play(filename, float64(maxWait))
 }

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 		err = cmd.Execute(command, title, assumeYes, maxWait, filename)
 
 	case "play":
-		maxWait := uintArg(args, "--max-wait", cfg.RecordMaxWait())
+		maxWait := uintArg(args, "--max-wait", cfg.PlaybackMaxWait())
 		filename := stringArg(args, "<filename>")
 		cmd := commands.NewPlayCommand()
 		err = cmd.Execute(filename, maxWait)

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ var usage = `Record and share your terminal sessions, the right way.
 
 Usage:
   asciinema rec [-c <command>] [-t <title>] [-w <sec>] [-y] [<filename>]
-  asciinema play <filename>
+  asciinema play [-w <sec>] <filename>
   asciinema upload <filename>
   asciinema auth
   asciinema -h | --help
@@ -127,9 +127,10 @@ func main() {
 		err = cmd.Execute(command, title, assumeYes, maxWait, filename)
 
 	case "play":
+		maxWait := uintArg(args, "--max-wait", cfg.RecordMaxWait())
 		filename := stringArg(args, "<filename>")
 		cmd := commands.NewPlayCommand()
-		err = cmd.Execute(filename)
+		err = cmd.Execute(filename, maxWait)
 
 	case "upload":
 		filename := stringArg(args, "<filename>")

--- a/util/cfg.go
+++ b/util/cfg.go
@@ -36,10 +36,10 @@ type ConfigUser struct {
 }
 
 type ConfigFile struct {
-	API    ConfigAPI
-	Record ConfigRecord
+	API      ConfigAPI
+	Record   ConfigRecord
 	Playback ConfigPlayback
-	User   ConfigUser // old location of token
+	User     ConfigUser // old location of token
 }
 
 type Config struct {

--- a/util/cfg.go
+++ b/util/cfg.go
@@ -27,6 +27,10 @@ type ConfigRecord struct {
 	Yes     bool
 }
 
+type ConfigPlayback struct {
+	MaxWait uint
+}
+
 type ConfigUser struct {
 	Token string
 }
@@ -34,6 +38,7 @@ type ConfigUser struct {
 type ConfigFile struct {
 	API    ConfigAPI
 	Record ConfigRecord
+	Playback ConfigPlayback
 	User   ConfigUser // old location of token
 }
 
@@ -60,6 +65,10 @@ func (c *Config) RecordMaxWait() uint {
 
 func (c *Config) RecordYes() bool {
 	return c.File.Record.Yes
+}
+
+func (c *Config) PlaybackMaxWait() uint {
+	return c.File.Playback.MaxWait
 }
 
 func GetConfig(env map[string]string) (*Config, error) {

--- a/util/cfg_test.go
+++ b/util/cfg_test.go
@@ -150,3 +150,28 @@ func TestConfig_RecordYes(t *testing.T) {
 		}
 	}
 }
+
+func TestConfig_PlaybackMaxWait(t *testing.T) {
+	var tests = []struct {
+		cfg      util.ConfigFile
+		expected uint
+	}{
+		{
+			util.ConfigFile{},
+			0,
+		},
+		{
+			util.ConfigFile{Playback: util.ConfigPlayback{MaxWait: 1}},
+			1,
+		},
+	}
+
+	for _, test := range tests {
+		cfg := util.Config{&test.cfg, nil}
+		actual := cfg.PlaybackMaxWait()
+
+		if actual != test.expected {
+			t.Errorf(`expected "%v", got "%v"`, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Take the -w option on playback, which reduces all intervals in the recorded
file to the specified number of seconds (or less)