### PR TITLE
Changed max-wait parameter type to float64

### DIFF
--- a/asciicast/player.go
+++ b/asciicast/player.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Player interface {
-	Play(*Asciicast, uint) error
+	Play(*Asciicast, float64) error
 }
 
 type AsciicastPlayer struct {
@@ -18,11 +18,11 @@ func NewPlayer() Player {
 	return &AsciicastPlayer{Terminal: terminal.NewTerminal()}
 }
 
-func (r *AsciicastPlayer) Play(asciicast *Asciicast, maxWait uint) error {
+func (r *AsciicastPlayer) Play(asciicast *Asciicast, maxWait float64) error {
 	for _, frame := range asciicast.Stdout {
 		delay := frame.Delay
-		if maxWait > 0 && delay > float64(maxWait) {
-			delay = float64(maxWait)
+		if maxWait > 0 && delay > maxWait {
+			delay = maxWait
 		}
 		time.Sleep(time.Duration(float64(time.Second) * delay))
 		r.Terminal.Write(frame.Data)

--- a/asciicast/recorder.go
+++ b/asciicast/recorder.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Recorder interface {
-	Record(string, string, string, uint, bool, map[string]string) error
+	Record(string, string, string, float64, bool, map[string]string) error
 }
 
 type AsciicastRecorder struct {
@@ -17,7 +17,7 @@ func NewRecorder() Recorder {
 	return &AsciicastRecorder{Terminal: terminal.NewTerminal()}
 }
 
-func (r *AsciicastRecorder) Record(path, command, title string, maxWait uint, assumeYes bool, env map[string]string) error {
+func (r *AsciicastRecorder) Record(path, command, title string, maxWait float64, assumeYes bool, env map[string]string) error {
 	// TODO: touch savePath to ensure writing is possible
 
 	rows, cols, _ := r.Terminal.Size()

--- a/asciicast/stream.go
+++ b/asciicast/stream.go
@@ -9,10 +9,10 @@ type Stream struct {
 	maxWait       time.Duration
 }
 
-func NewStream(maxWait uint) *Stream {
+func NewStream(maxWait float64) *Stream {
 	return &Stream{
 		lastWriteTime: time.Now(),
-		maxWait:       time.Duration(maxWait) * time.Second,
+		maxWait:       time.Duration(maxWait*1000000) * time.Microsecond,
 	}
 }
 

--- a/commands/play.go
+++ b/commands/play.go
@@ -15,7 +15,7 @@ func NewPlayCommand() *PlayCommand {
 	}
 }
 
-func (c *PlayCommand) Execute(url string, maxWait uint) error {
+func (c *PlayCommand) Execute(url string, maxWait float64) error {
 	var cast *asciicast.Asciicast
 	var err error
 

--- a/commands/rec.go
+++ b/commands/rec.go
@@ -24,7 +24,7 @@ func NewRecordCommand(api api.API, env map[string]string) *RecordCommand {
 	}
 }
 
-func (c *RecordCommand) Execute(command, title string, assumeYes bool, maxWait uint, filename string) error {
+func (c *RecordCommand) Execute(command, title string, assumeYes bool, maxWait float64, filename string) error {
 	var upload bool
 	var err error
 

--- a/commands/rec_test.go
+++ b/commands/rec_test.go
@@ -11,7 +11,7 @@ type testRecorder struct {
 	err error
 }
 
-func (r *testRecorder) Record(path, command, title string, maxWait uint, assumeYes bool, env map[string]string) error {
+func (r *testRecorder) Record(path, command, title string, maxWait float64, assumeYes bool, env map[string]string) error {
 	return r.err
 }
 

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ Commands:
 Options:
   -c, --command=<command>  Specify command to record, defaults to $SHELL
   -t, --title=<title>      Specify title of the asciicast
-  -w, --max-wait=<sec>     Reduce recorded terminal inactivity to max <sec> seconds
+  -w, --max-wait=<sec>     Reduce recorded terminal inactivity to max <sec> seconds (can be fractional)
   -y, --yes                Answer "yes" to all prompts (e.g. upload confirmation)
   -q, --quiet              Be quiet, suppress all notices/warnings (implies -y)
   -h, --help               Show this message
@@ -64,14 +64,14 @@ func boolArg(args map[string]interface{}, name string) bool {
 	return args[name].(bool)
 }
 
-func uintArg(args map[string]interface{}, name string, defaultValue uint) uint {
+func floatArg(args map[string]interface{}, name string, defaultValue float64) float64 {
 	val := args[name]
 
 	if val != nil {
-		number, err := strconv.ParseUint(val.(string), 10, 0)
+		number, err := strconv.ParseFloat(val.(string), 64)
 
 		if err == nil {
-			return uint(number)
+			return float64(number)
 		}
 	}
 
@@ -134,13 +134,13 @@ func main() {
 			assumeYes = true
 		}
 
-		maxWait := uintArg(args, "--max-wait", cfg.RecordMaxWait())
+		maxWait := floatArg(args, "--max-wait", cfg.RecordMaxWait())
 		filename := stringArg(args, "<filename>")
 		cmd := commands.NewRecordCommand(api, env)
 		err = cmd.Execute(command, title, assumeYes, maxWait, filename)
 
 	case "play":
-		maxWait := uintArg(args, "--max-wait", cfg.PlayMaxWait())
+		maxWait := floatArg(args, "--max-wait", cfg.PlayMaxWait())
 		filename := stringArg(args, "<filename>")
 		cmd := commands.NewPlayCommand()
 		err = cmd.Execute(filename, maxWait)

--- a/util/cfg.go
+++ b/util/cfg.go
@@ -23,12 +23,12 @@ type ConfigAPI struct {
 
 type ConfigRecord struct {
 	Command string
-	MaxWait uint
+	MaxWait float64
 	Yes     bool
 }
 
 type ConfigPlay struct {
-	MaxWait uint
+	MaxWait float64
 }
 
 type ConfigUser struct {
@@ -59,7 +59,7 @@ func (c *Config) RecordCommand() string {
 	return FirstNonBlank(c.File.Record.Command, c.Env["SHELL"], DefaultCommand)
 }
 
-func (c *Config) RecordMaxWait() uint {
+func (c *Config) RecordMaxWait() float64 {
 	return c.File.Record.MaxWait
 }
 
@@ -67,7 +67,7 @@ func (c *Config) RecordYes() bool {
 	return c.File.Record.Yes
 }
 
-func (c *Config) PlayMaxWait() uint {
+func (c *Config) PlayMaxWait() float64 {
 	return c.File.Play.MaxWait
 }
 

--- a/util/cfg_test.go
+++ b/util/cfg_test.go
@@ -104,15 +104,15 @@ func TestConfig_RecordCommand(t *testing.T) {
 func TestConfig_RecordMaxWait(t *testing.T) {
 	var tests = []struct {
 		cfg      util.ConfigFile
-		expected uint
+		expected float64
 	}{
 		{
 			util.ConfigFile{},
 			0,
 		},
 		{
-			util.ConfigFile{Record: util.ConfigRecord{MaxWait: 1}},
-			1,
+			util.ConfigFile{Record: util.ConfigRecord{MaxWait: 1.23456}},
+			1.23456,
 		},
 	}
 
@@ -154,15 +154,15 @@ func TestConfig_RecordYes(t *testing.T) {
 func TestConfig_PlayMaxWait(t *testing.T) {
 	var tests = []struct {
 		cfg      util.ConfigFile
-		expected uint
+		expected float64
 	}{
 		{
 			util.ConfigFile{},
 			0,
 		},
 		{
-			util.ConfigFile{Play: util.ConfigPlay{MaxWait: 1}},
-			1,
+			util.ConfigFile{Play: util.ConfigPlay{MaxWait: 1.23456}},
+			1.23456,
 		},
 	}
 


### PR DESCRIPTION
Nothing sophisticated, just changed the type in all places. I'm not proficient in Go, so excuse me if I did something stupid. Possible improvements:
- indicate this change in the docs explicitly
- check that the input parameter is positive and print an error otherwise