### PR TITLE
setup: distutils can't create wrapper in $PATH

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,7 @@ import sys
 if sys.version_info[0] < 3:
     sys.exit('Python < 3 is unsupported.')
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
-
+from setuptools import setup
 import asciinema
 
 


### PR DESCRIPTION
Module `distutils` don't know options `install_requires` and
`entry_points`. The second one is important for creating `asciinema`
binary within $PATH.

This should "resolve" Issue #174.