### PR TITLE
Add start-at option to play command

### DIFF
--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -26,7 +26,7 @@ def rec_command(args, config):
 
 
 def play_command(args, config):
-    return PlayCommand(args.filename, args.max_wait)
+    return PlayCommand(args.filename, max_wait=args.max_wait, start_at=args.start_at)
 
 
 def upload_command(args, config):
@@ -88,6 +88,7 @@ For help on a specific command run:
     # create the parser for the "play" command
     parser_play = subparsers.add_parser('play', help='Replay terminal session')
     parser_play.add_argument('-w', '--max-wait', help='limit terminal inactivity to max <sec> seconds (can be fractional)', type=positive_float, default=maybe_str(cfg.play_max_wait))
+    parser_play.add_argument('-t', '--time', metavar='SEC', dest='start_at', help='start replay at <SEC>-th second', type=positive_float, default=0)
     parser_play.add_argument('filename', help='local path, http/ipfs URL or "-" (read from stdin)')
     parser_play.set_defaults(func=play_command)
 

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -5,15 +5,16 @@ import asciinema.asciicast as asciicast
 
 class PlayCommand(Command):
 
-    def __init__(self, filename, max_wait, player=None):
+    def __init__(self, filename, max_wait, player=None, start_at=0):
         Command.__init__(self)
         self.filename = filename
         self.max_wait = max_wait
         self.player = player if player is not None else Player()
+        self.start_at = start_at
 
     def execute(self):
         try:
-            self.player.play(asciicast.load(self.filename), self.max_wait)
+            self.player.play(asciicast.load(self.filename), self.max_wait, self.start_at)
 
         except asciicast.LoadError as e:
             self.print_warning("Playback failed: %s" % str(e))

--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -3,8 +3,13 @@ import time
 
 class Player:
 
-    def play(self, asciicast, max_wait=None):
+    def play(self, asciicast, max_wait=None, start_at=0):
+        start = 0
         for delay, text in asciicast.stdout:
+            start = start + delay
+            if start < start_at:
+                continue
+
             if max_wait and delay > max_wait:
                 delay = max_wait
             time.sleep(delay)

--- a/man/asciinema.1
+++ b/man/asciinema.1
@@ -67,6 +67,9 @@ Available options:
 .TP
 \-w, \-\-max\-wait
 reduce replayed terminal inactivity to max \fIsec\fP seconds
+.TP
+\-t, \-\-time
+start playback at \fIsec\fP-th second
 .RE
 .RE
 .PP


### PR DESCRIPTION
option -s / --start-at allows user to start replay of a file at a
specified sec. It's quite stupid implemetnation, but should be enough for
review of a big file.

The logic behind is in Player class where sum of delays runs first in
every loop and if this sum is bigger than intended time, than we start
replaying.

This is a part of solution of Issue #118.
