### PR TITLE
add support for 'asciinema rec' to specify script to run via -s/--script

### DIFF
--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -22,7 +22,7 @@ def positive_float(value):
 
 def rec_command(args, config):
     api = Api(config.api_url, os.environ.get("USER"), config.api_token)
-    return RecordCommand(api, args.filename, args.command, args.title, args.yes, args.quiet, args.max_wait)
+    return RecordCommand(api, args.filename, args.command, args.script, args.title, args.yes, args.quiet, args.max_wait)
 
 
 def play_command(args, config):
@@ -78,6 +78,7 @@ For help on a specific command run:
     # create the parser for the "rec" command
     parser_rec = subparsers.add_parser('rec', help='Record terminal session')
     parser_rec.add_argument('-c', '--command', help='command to record, defaults to $SHELL', default=cfg.record_command)
+    parser_rec.add_argument('-s', '--script', help='script to record', default=cfg.record_script)
     parser_rec.add_argument('-t', '--title', help='title of the asciicast')
     parser_rec.add_argument('-w', '--max-wait', help='limit recorded terminal inactivity to max <sec> seconds (can be fractional)', type=positive_float, default=maybe_str(cfg.record_max_wait))
     parser_rec.add_argument('-y', '--yes', help='answer "yes" to all prompts (e.g. upload confirmation)', action='store_true', default=cfg.record_yes)

--- a/asciinema/commands/record.py
+++ b/asciinema/commands/record.py
@@ -9,11 +9,12 @@ from asciinema.api import APIError
 
 class RecordCommand(Command):
 
-    def __init__(self, api, filename, command, title, assume_yes, quiet, max_wait, recorder=None):
+    def __init__(self, api, filename, command, script, title, assume_yes, quiet, max_wait, recorder=None):
         Command.__init__(self, quiet)
         self.api = api
         self.filename = filename
         self.command = command
+        self.script = script
         self.title = title
         self.assume_yes = assume_yes or quiet
         self.max_wait = max_wait
@@ -33,9 +34,10 @@ class RecordCommand(Command):
             return 1
 
         self.print_info("Asciicast recording started.")
-        self.print_info("""Hit Ctrl-D or type "exit" to finish.""")
+        if not self.script:
+            self.print_info("""Hit Ctrl-D or type "exit" to finish.""")
 
-        self.recorder.record(self.filename, self.command, self.title, self.max_wait)
+        self.recorder.record(self.filename, self.command, self.script, self.title, self.max_wait)
 
         self.print_info("Asciicast recording finished.")
 

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -40,6 +40,10 @@ class Config:
         return self.config.get('record', 'command', fallback=None)
 
     @property
+    def record_script(self):
+        return self.config.get('record', 'script', fallback=None)
+
+    @property
     def record_max_wait(self):
         return self.config.getfloat('record', 'maxwait', fallback=None)
 

--- a/asciinema/recorder.py
+++ b/asciinema/recorder.py
@@ -12,13 +12,16 @@ class Recorder:
         self.pty_recorder = pty_recorder if pty_recorder is not None else PtyRecorder()
         self.env = env if env is not None else os.environ
 
-    def record(self, path, user_command, title, max_wait):
+    def record(self, path, user_command, script, title, max_wait):
         command = user_command or self.env.get('SHELL') or 'sh'
         stdout = Stdout(max_wait)
         env = os.environ.copy()
         env['ASCIINEMA_REC'] = '1'
 
-        self.pty_recorder.record_command(['sh', '-c', command], stdout, env)
+        if script:
+            self.pty_recorder.record_script(script, stdout, env)
+        else:
+            self.pty_recorder.record_command(['sh', '-c', command], stdout, env)
 
         width = int(subprocess.check_output(['tput', 'cols']))
         height = int(subprocess.check_output(['tput', 'lines']))


### PR DESCRIPTION
I recently started looking into `asciinema`, and wanted to see if I could leverage it to record demo sessions for EasyBuild (http://hpcugent.github.io/easybuild/), and use/embed these demos into our documentation.

I was quickly convinced that `asciinema` could be very useful, and started working on putting together a demo to evaluate the experience.
I had a good idea of what I wanted to include in the demo, but found myself making silly mistakes (e.g. typos in commands) while recording the interactive session via `asciinema rec`, forcing me to start over again a couple of times.
In addition, I was worried about updating these demos later: I would have to reproduce the steps of the demo again, and retype the 'comments' I wanted to include in there as well, making sure not to make any typos, etc.

Basically, what I was missing was a way to provide a script to `asciinema rec`, while also having the ability to specify blocks of 'comments' to be included in the recorded session.

This patch implements support for the `--script` (`-s`) option to `asciinema rec`.

It supports providing a script the lists the commands to execute, which will look like they are typed by a human (I feel that's an important aspect of a demo).
In addition, you can include comments in the script, that will be either 'copy-pasted' as a block, or which will be 'typed' as if a human entered them interactively, as well as 'hidden' commands which will be executed but not shown as being 'typed' (which can be useful to prepare the environment in which the demo will be run).

Each line in the script is interpreted based on whether it starts with a `#` (and if so, how many):

* no `#`:  a command to 'type' and execute
* `###`: a comment that should be 'typed'
* `##`: a comment that should be printed as a whole (not 'typed')
* `# `: (that is, `<hash>-<space>`) a 'hidden' command to execute (not 'type')

In addition, a couple of keywords are recognised:

* a line that starts with `PAUSE` specifies that the demo should 'freeze' for a specified number of seconds
* a line equal to `CLEAR` specifies that the screen should be cleared (i.e. a `clear` command is executed)
* in any 'typed' lines (commands or comments):
  * `TAB` indicates that the line should complete until the next space or `/`
  * `COPYPASTE` indicates that the line should complete until the next space

I'm contributing this 'as-is', since it works, but I'm happy to get feedback and suggestions for improvements on the implementation. I imagine one thing that's missing for this to be included is tests for `rec --script`...


A demo of `asciinema rec --script` in action is shown at https://asciinema.org/a/89319; it was created with the script shown below:

```
CLEAR
## Demo of 'asciinema rec --script', recorded with:
PAUSE 2
### asciinema rec --script demo.script

echo hello

### Result of a hidden 'echo boo!' command:
# echo 'boo!'

### Clearing the screen in
### 3
PAUSE 1
### 2
PAUSE 1
### 1
PAUSE 1
CLEAR

### The asciinema website can be found at COPYPASTEhttp://asciinema.org
echo "Tab completion is so cool, see: /tmp/naTABmeofaverylongfilethatwouldtakeawhiletotype"
```


A real-world example asciinema recording created with this is available at https://asciinema.org/a/88511 (embedded into our docs at http://easybuild.readthedocs.io/en/latest/demos/configuring.html); the script is was created with is available at https://github.com/hpcugent/easybuild/blob/master/docs/demos/scripts/configuring.script.