### PR TITLE
adding support to loading API token from an environment variable

### DIFF
--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -33,7 +33,11 @@ class Config:
             try:
                 return self.config.get('user', 'token')
             except (configparser.NoOptionError, configparser.NoSectionError):
-                raise ConfigError('no API token found in config file')
+                environment_variable_fallback = self.env.get('ASCIINEMA_TOKEN')
+                if environment_variable_fallback is not None:
+                    return environment_variable_fallback
+                else:
+                    raise ConfigError('no API token found in config file, and ASCIINEMA_TOKEN is unset')
 
     @property
     def record_command(self):

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -1,4 +1,4 @@
-simport os
+import os
 import os.path as path
 import sys
 import uuid

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -1,4 +1,4 @@
-import os
+simport os
 import os.path as path
 import sys
 import uuid
@@ -28,16 +28,12 @@ class Config:
     @property
     def api_token(self):
         try:
-            return self.config.get('api', 'token')
+            return self.env.get('ASCIINEMA_API_TOKEN', self.config.get('api', 'token'))
         except (configparser.NoOptionError, configparser.NoSectionError):
             try:
                 return self.config.get('user', 'token')
             except (configparser.NoOptionError, configparser.NoSectionError):
-                environment_variable_fallback = self.env.get('ASCIINEMA_TOKEN')
-                if environment_variable_fallback is not None:
-                    return environment_variable_fallback
-                else:
-                    raise ConfigError('no API token found in config file, and ASCIINEMA_TOKEN is unset')
+                raise ConfigError('no API token found in config file, and ASCIINEMA_API_TOKEN is unset')
 
     @property
     def record_command(self):

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -28,7 +28,7 @@ class Config:
     @property
     def api_token(self):
         try:
-            return self.env.get('ASCIINEMA_API_TOKEN', self.config.get('api', 'token'))
+            return self.env.get('ASCIINEMA_API_TOKEN') or self.config.get('api', 'token')
         except (configparser.NoOptionError, configparser.NoSectionError):
             try:
                 return self.config.get('user', 'token')


### PR DESCRIPTION
This addresses #185, by adding a new fallback method of an environment variable named `ASCIINEMA_TOKEN` to store the user's API token so that sensitive information doesn't have to be kept in plaintext on disk.