### PR TITLE
Ignore stdin during playback

### DIFF
--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -1,5 +1,6 @@
 import curses
 
+
 class CursesWrapper:
     def __init__(self):
         self._stdscr = curses.initscr()
@@ -14,6 +15,7 @@ class CursesWrapper:
         # Flush stdin and clean up terminal
         curses.flushinp()
         curses.endwin()
+
 
 class Player:
 

--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -1,13 +1,28 @@
+import curses
 import sys
 import time
 
+class CursesWrapper:
+    def __init__(self):
+        self._stdscr = curses.initscr()
+
+    def __enter__(self):
+        curses.noecho()
+        curses.cbreak()
+        self._stdscr.keypad(1)
+        return self
+
+    def __exit__(self, type, value, traceback):
+        curses.flushinp()
+        curses.endwin()
 
 class Player:
 
     def play(self, asciicast, max_wait=None, speed=1.0):
-        for delay, text in asciicast.stdout:
-            if max_wait and delay > max_wait:
-                delay = max_wait
-            time.sleep(delay / speed)
-            sys.stdout.write(text)
-            sys.stdout.flush()
+        with CursesWrapper():
+            for delay, text in asciicast.stdout:
+                if max_wait and delay > max_wait:
+                    delay = max_wait
+                time.sleep(delay / speed)
+                sys.stdout.write(text)
+                sys.stdout.flush()

--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -1,6 +1,4 @@
 import curses
-import sys
-import time
 
 class CursesWrapper:
     def __init__(self):
@@ -13,6 +11,7 @@ class CursesWrapper:
         return self
 
     def __exit__(self, type, value, traceback):
+        # Flush stdin and clean up terminal
         curses.flushinp()
         curses.endwin()
 
@@ -23,6 +22,8 @@ class Player:
             for delay, text in asciicast.stdout:
                 if max_wait and delay > max_wait:
                     delay = max_wait
-                time.sleep(delay / speed)
-                sys.stdout.write(text)
-                sys.stdout.flush()
+                delay_ms = int(delay * 1000 / speed)
+                curses.delay_output(delay_ms)
+                text_bytes = text.encode('utf-8')
+                curses.putp(text_bytes)
+                curses.doupdate()


### PR DESCRIPTION
Potential fix for #108 using `curses`.

Also has the side-effect of clearing the terminal at the beginning of the playback and restoring it afterward, which seems like a good thing.

It would be pretty easy to implement #198 on top of this as well, since retrieving and setting the terminal size are simple functions in `curses`