### PR TITLE
Don't save user command, to avoid leaking secrets

### DIFF
--- a/asciinema/asciicast/v2.py
+++ b/asciinema/asciicast/v2.py
@@ -107,9 +107,6 @@ class Recorder:
         if title:
             header['title'] = title
 
-        if user_command:
-            header['command'] = user_command
-
         command = user_command or self.env.get('SHELL') or 'sh'
 
         with incremental_writer(path, header, rec_stdin) as w:


### PR DESCRIPTION
This solves #216.

Example of secret leak:

    asciinema rec -c 'export API_KEY=secret-stuff; ./script.sh'

The resulting asciicast would include `"command": "export API_KEY=secret-stuff; ./script.sh"`.