### PR TITLE
Manual page additions

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -1,2 +1,5 @@
+VERSION=`python3 -c "import asciinema; print(asciinema.__version__)"`
+
 asciinema.1: asciinema.1.md
-	pandoc asciinema.1.md -s -t man -o asciinema.1
+	pandoc asciinema.1.md -s -t man -o asciinema.1 -V header:"Version $(VERSION), `date +%Y-%m-%d`"
+

--- a/man/asciinema.1.md
+++ b/man/asciinema.1.md
@@ -1,9 +1,11 @@
 % ASCIINEMA(1) Version 2.0 | asciinema
 
+
 NAME
 ====
 
 **asciinema** - terminal session recorder
+
 
 SYNOPSIS
 ========
@@ -11,11 +13,15 @@ SYNOPSIS
 | **asciinema \-\-version**
 | **asciinema** _command_ \[_options_] \[_args_]
 
+
 DESCRIPTION
 ===========
 
-asciinema lets you easily record terminal sessions and replay
-them in a terminal as well as in a web browser.
+asciinema lets you easily record terminal sessions, replay
+them in a terminal as well as in a web browser and share them on the web.
+asciinema is Free and Open Source Software licensed under
+the GNU General Public License v3.
+
 
 COMMANDS
 ========
@@ -23,8 +29,9 @@ COMMANDS
 asciinema is composed of multiple commands, similar to `git`, `apt-get` or
 `brew`.
 
-When you run **asciinema** with no arguments help message is displayed, listing
+When you run **asciinema** with no arguments a help message is displayed, listing
 all available commands with their options.
+
 
 rec [_filename_]
 ---
@@ -55,37 +62,37 @@ prompt or play a sound when the shell is being recorded.
 
 Available options:
 
-: &nbsp;
+:   &nbsp;
 
     `--stdin`
-    : Enable stdin (keyboard) recording (see below)
+    :   Enable stdin (keyboard) recording (see below)
 
     `--append`
-    : Append to existing recording
+    :   Append to existing recording
 
     `--raw`
-    : Save raw STDOUT output, without timing information or other metadata
+    :   Save raw STDOUT output, without timing information or other metadata
 
     `--overwrite`
-    : Overwrite the recording if it already exists
+    :   Overwrite the recording if it already exists
 
     `-c, --command=<command>`
-    : Specify command to record, defaults to **$SHELL**
+    :   Specify command to record, defaults to **$SHELL**
 
     `-e, --env=<var-names>`
-    : List of environment variables to capture, defaults to **SHELL,TERM**
+    :   List of environment variables to capture, defaults to **SHELL,TERM**
 
     `-t, --title=<title>`
-    : Specify the title of the asciicast
+    :   Specify the title of the asciicast
 
     `-i, --idle-time-limit=<sec>`
-    : Limit recorded terminal inactivity to max `<sec>` seconds
+    :   Limit recorded terminal inactivity to max `<sec>` seconds
 
     `-y, --yes`
-    : Answer "yes" to all prompts (e.g. upload confirmation)
+    :   Answer "yes" to all prompts (e.g. upload confirmation)
 
     `-q, --quiet`
-    : Be quiet, suppress all notices/warnings (implies **-y**)
+    :   Be quiet, suppress all notices/warnings (implies **-y**)
 
 Stdin recording allows for capturing of all characters typed in by the user in
 the currently recorded shell. This may be used by a player (e.g.
@@ -94,19 +101,14 @@ pressed keys. Because it's basically a key-logging (scoped to a single shell
 instance), it's disabled by default, and has to be explicitly enabled via
 **--stdin** option.
 
+
 play <_filename_>
 ---
 
 Replay recorded asciicast in a terminal.
 
-This command replays given asciicast (as recorded by **rec** command) directly in
-your terminal.
-
-Following keyboard shortcuts are available:
-
-    Space - toggle pause,
-    . - step through a recording a frame at a time (when paused),
-    Ctrl+C - exit.
+This command replays a given asciicast (as recorded by **rec** command) directly in
+your terminal. The asciicast can be read from a file or from *`stdin`* ('-'):
 
 Playing from a local file:
 
@@ -134,13 +136,31 @@ Playing from IPFS:
 
 Available options:
 
-: &nbsp;
+:   &nbsp;
 
     `-i, --idle-time-limit=<sec>`
-    : Limit replayed terminal inactivity to max `<sec>` seconds
+    : Limit replayed terminal inactivity to max `<sec>` seconds (can be fractional)
 
     `-s, --speed=<factor>`
     : Playback speed (can be fractional)
+
+While playing the following keyboard shortcuts are available:
+
+:    &nbsp;
+
+    *`Space`*
+    :   Toggle pause
+
+    *`.`*
+    :   Step through a recording a frame at a time (when paused)
+
+    *`Ctrl+C`*
+    :   Exit
+
+Recommendation: run 'asciinema play' in a terminal of dimensions not smaller than the one
+used for recording as there's no "transcoding" of control sequences for the new terminal
+size.
+
 
 cat <_filename_>
 ---
@@ -154,8 +174,9 @@ output (including all escape sequences) to a terminal immediately.
 **asciinema cat existing.cast >output.txt** gives the same result as recording via
 **asciinema rec \-\-raw output.txt**.
 
-upload <filename>
----
+
+upload <_filename_>
+------
 
 Upload recorded asciicast to asciinema.org site.
 
@@ -167,12 +188,12 @@ demo.cast** is a nice combo if you want to review an asciicast before
 publishing it on asciinema.org.
 
 auth
----
+----
 
-Link your install ID with your asciinema.org user account.
+Link and manage your install ID with your asciinema.org user account.
 
 If you want to manage your recordings (change title/theme, delete) at
-asciinema.org you need to link your "install ID" with asciinema.org user
+asciinema.org you need to link your "install ID" with your asciinema.org user
 account.
 
 This command displays the URL to open in a web browser to do that. You may be
@@ -187,11 +208,18 @@ account. This way we decouple uploading from account creation, allowing them to
 happen in any order.
 
 Note: A new install ID is generated on each machine and system user account you use
-asciinema on, so in order to keep all recordings under a single asciinema.org
-account you need to run **asciinema auth** on all of those machines.
+asciinema on. So in order to keep all recordings under a single asciinema.org
+account you need to run **asciinema auth** on all of those machines. If you’re
+already logged in on asciinema.org website and you run 'asciinema auth' from a new
+computer then this new device will be linked to your account.
+
+While you CAN synchronize your config file (which keeps the API token) across
+all your machines so all use the same token, that’s not necessary. You can assign
+new tokens to your account from as many machines as you want.
 
 Note: asciinema versions prior to 2.0 confusingly referred to install ID as "API
 token".
+
 
 EXAMPLES
 ========
@@ -199,6 +227,10 @@ EXAMPLES
 Record your first session:
 
     asciinema rec first.cast
+
+End your session:
+
+    exit
 
 Now replay it with double speed:
 
@@ -228,24 +260,67 @@ You can record and upload in one step by omitting the filename:
 You'll be asked to confirm the upload when the recording is done, so nothing is
 sent anywhere without your consent.
 
+
+Tricks
+------
+
+Record slowly, play faster:
+
+:   First record a session where you can take your time to type slowly what you want
+    to show in the recording:
+
+        asciinema rec initial.cast
+
+    Then record the replay of 'initial.cast' as 'final.cast', but with five times the
+    initially recorded speed, with all pauses capped to two seconds and with a title
+    set as "My fancy title"::
+
+        asciinema rec -c "asciinema play -s 5 -i 2 initial.cast" -t "My fancy title" final.cast
+
+Play from *`stdin`*:
+
+:   &nbsp;
+
+    cat /path/to/asciicast.json | asciinema play -
+
+Play file from remote host accessible with SSH:
+
+:   &nbsp;
+
+    ssh user@host cat /path/to/asciicat.json | asciinema play -
+
+
 ENVIRONMENT
 ===========
 
 **ASCIINEMA_API_URL**
 
-: This variable allows overriding asciinema-server URL (which defaults to
-  https://asciinema.org) in case you're running your own asciinema-server instance.
+:   This variable allows overriding asciinema-server URL (which defaults to
+    https://asciinema.org) in case you're running your own asciinema-server instance.
 
 **ASCIINEMA_CONFIG_HOME**
 
-: This variable allows overriding config directory location. Default location
-  is $XDG\_CONFIG\_HOME/asciinema (when $XDG\_CONFIG\_HOME is set)
-  or $HOME/.config/asciinema.
+:   This variable allows overriding config directory location. Default location
+    is $XDG\_CONFIG\_HOME/asciinema (when $XDG\_CONFIG\_HOME is set)
+    or $HOME/.config/asciinema.
+
 
 BUGS
 ====
 
 See GitHub Issues: <https://github.com/asciinema/asciinema/issues>
+
+
+MORE RESSOURCES
+===============
+
+More documentation is available on the asciicast.org website and its GitHub wiki:
+
+* Web:  [asciinema.org/docs/](https://asciinema.org/docs/)
+* Wiki: [github.com/asciinema/asciinema/wiki](https://github.com/asciinema/asciinema/wiki) 
+* IRC:  [Channel on Freenode](https://webchat.freenode.net/?channels=asciinema)
+* Twitter: [@asciinema](https://twitter.com/asciinema)
+
 
 AUTHORS
 =======
@@ -255,3 +330,4 @@ asciinema's lead developer is Marcin Kulik.
 For a list of all contributors look here: <https://github.com/asciinema/asciinema/contributors>
 
 This Manual Page was written by Marcin Kulik with help from Kurt Pfeifle.
+


### PR DESCRIPTION
My changes include:

1. *`asciinema.1.md`* source file for manual page is extended by a few pieces.
1. *`Makefile`* command for Pandoc to generate the manual page is modified to include version+date of manual page generation.

This PR does NOT include:

+ A freshly generated *`asciinema.1`* manual page -- this has to be run on your side should you accept (parts of) my suggested additions.

Note, I have not included an actual *`asciinema.1`* manual page due to the fact that my local Pandoc is still stuck with v.1.19.2.4 whereas you seem to be using v2.1.1 already, and I didn't want to push too many minor backward changes like with 'smart quotes' etc.