### PR TITLE
Use `encodebytes` instead of `encodestring` (deprecated since Python 3.1)

### DIFF
--- a/asciinema/urllib_http_adapter.py
+++ b/asciinema/urllib_http_adapter.py
@@ -67,7 +67,7 @@ class URLLibHttpAdapter:
 
         if password:
             auth = "%s:%s" % (username, password)
-            encoded_auth = base64.encodestring(auth.encode('utf-8'))[:-1]
+            encoded_auth = base64.encodebytes(auth.encode('utf-8'))[:-1]
             headers["Authorization"] = b"Basic " + encoded_auth
 
         request = Request(url, data=body, headers=headers, method="POST")


### PR DESCRIPTION
> ### base64.encodestring(s)
> Deprecated alias of encodebytes().
> ***Deprecated since version 3.1.***

* https://docs.python.org/3/library/base64.html#base64.encodestring
