### PR TITLE
Swap TERM and SHELL in v2 file format example

### DIFF
--- a/doc/asciicast-v2.md
+++ b/doc/asciicast-v2.md
@@ -71,8 +71,8 @@ Example env:
 
 ```json
 "env": {
-  "SHELL": "xterm-256color",
-  "TERM": "/bin/bash"
+  "SHELL": "/bin/bash",
+  "TERM": "xterm-256color"
 }
 ```
 


### PR DESCRIPTION
The v2 file format [example for `env`](https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md#env) has the `TERM` and `SHELL` variables swapped:

```json
"env": {
  "SHELL": "xterm-256color",
  "TERM": "/bin/bash"
}
```

This commit fixes that by swapping them back.