### PR TITLE
Stop exiting needlessly on plain "C" locales

### DIFF
--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -50,8 +50,8 @@ def maybe_str(v):
 
 
 def main():
-    if locale.nl_langinfo(locale.CODESET).upper() != 'UTF-8':
-        print("asciinema needs a UTF-8 native locale to run. Check the output of `locale` command.")
+    if locale.nl_langinfo(locale.CODESET).upper() not in ['US-ASCII', 'UTF-8']:
+        print("asciinema needs an ASCII or UTF-8 character encoding to run. Check the output of `locale` command.")
         sys.exit(1)
 
     try:


### PR DESCRIPTION
Without setting a specific *.UTF-8 locale, things default to C,
which uses a US-ASCII character encoding.

Default installs of at least OpenBSD (and likely other systems)
fall into this category, and asciinema refuses to run at all.

This is **ascii**nema after all... it should support ascii!