### PR TITLE
Add configuration for which keys pause and step playback

### DIFF
--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -27,7 +27,10 @@ def rec_command(args, config):
 
 
 def play_command(args, config):
-    return PlayCommand(args.filename, args.idle_time_limit, args.speed)
+    chars = {}
+    chars['pause'] = config.play_pause_chars
+    chars['step'] = config.play_step_chars
+    return PlayCommand(args.filename, args.idle_time_limit, args.speed, chars)
 
 
 def cat_command(args, config):

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -5,17 +5,18 @@ import asciinema.asciicast as asciicast
 
 class PlayCommand(Command):
 
-    def __init__(self, filename, idle_time_limit, speed, player=None):
+    def __init__(self, filename, idle_time_limit, speed, chars, player=None):
         Command.__init__(self)
         self.filename = filename
         self.idle_time_limit = idle_time_limit
         self.speed = speed
+        self.chars = chars
         self.player = player if player is not None else Player()
 
     def execute(self):
         try:
             with asciicast.open_from_url(self.filename) as a:
-                self.player.play(a, self.idle_time_limit, self.speed)
+                self.player.play(a, self.idle_time_limit, self.speed, self.chars)
 
         except asciicast.LoadError as e:
             self.print_error("playback failed: %s" % str(e))

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -118,6 +118,14 @@ class Config:
     def play_speed(self):
         return self.config.getfloat('play', 'speed', fallback=1.0)
 
+    @property
+    def play_step_chars(self):
+        return self.config.get('play', 'step_chars', fallback='.')
+
+    @property
+    def play_pause_chars(self):
+        return self.config.get('play', 'pause_chars', fallback=' ')
+
 
 def get_config_home(env=os.environ):
     env_asciinema_config_home = env.get("ASCIINEMA_CONFIG_HOME")

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -187,3 +187,13 @@ def test_play_idle_time_limit():
 
     config = create_config("[play]\nmaxwait = 2.35")
     assert_equal(2.35, config.play_idle_time_limit)
+
+
+def test_play_step_chars():
+    config = create_config("[play]\nstep_chars = %s" % 'abcde')
+    assert_equal("abcde", config.play_step_chars)
+
+
+def test_play_pause_chars():
+    config = create_config("[play]\npause_chars = %s" % 'pause')
+    assert_equal("pause", config.play_pause_chars)


### PR DESCRIPTION
**What this changes** This adds configuration options for which characters will cause playback to pause and step through playback
**Why** I'm demoing [Bolt](https://github.com/puppetlabs/bolt) at Puppetize Live next week, and wanted a tool that would allow me to look like I'm typing while having a predictable demo. There's a similar tool that does this, 'Demo easel', but it only works on OSX and Windows. Since I didn't want to mess with a VM during my demos, hacking this together seemed like the easiest way to get a close approximation.