### PR TITLE
Edit recorded asciicasts, delete or squash events, concatenate recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,21 @@ output (including all escape sequences) to a terminal immediately.
 `asciinema cat existing.cast >output.txt` gives the same result as recording via
 `asciinema rec --raw output.txt`.
 
+### `edit -f <edited-file-1> [-f <edited-file-2> ...] <result-filename>`
+
+__Process manually edited asciicasts and join them to a single recording.__
+
+Take one or more asciicast files and edit them manually. Change the event
+types (it's the second item and usually an "o") as follows,
+
+- "d": delete, this event will be deleted
+- "s": squash, this event will be squashed onto the previous one. 
+  More consecutive lines can be squashed.
+
+After the individual files are processed, they are concatenated into a single
+recording. The times are adjusted, so the last event in the first file is 
+immediately followed by the first event in the second file, and so on.
+
 ### `upload <filename>`
 
 __Upload recorded asciicast to asciinema.org site.__

--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -119,7 +119,7 @@ For help on a specific command run:
     parser_cat.set_defaults(func=cat_command)
 
     # create the parser for the "edit" command
-    parser_edit = subparsers.add_parser('edit', help='Edit one or more recordings and save the result to a new recording')
+    parser_edit = subparsers.add_parser('edit', help='Edit recordings and concatenate them')
     parser_edit.add_argument('filename', help='filename/path to save the edited recording to')
     parser_edit.add_argument('-f', '--from-file', help='file(s) to edit', action='append')
     parser_edit.set_defaults(func=edit_command)

--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -9,6 +9,7 @@ from asciinema.commands.auth import AuthCommand
 from asciinema.commands.record import RecordCommand
 from asciinema.commands.play import PlayCommand
 from asciinema.commands.cat import CatCommand
+from asciinema.commands.edit import EditCommand
 from asciinema.commands.upload import UploadCommand
 from asciinema.api import Api
 
@@ -33,6 +34,9 @@ def play_command(args, config):
 def cat_command(args, config):
     return CatCommand(args.filename)
 
+
+def edit_command(args, config):
+    return EditCommand(args.from_file, args.filename)
 
 def upload_command(args, config):
     api = Api(config.api_url, os.environ.get("USER"), config.install_id)
@@ -113,6 +117,12 @@ For help on a specific command run:
     parser_cat = subparsers.add_parser('cat', help='Print full output of terminal session')
     parser_cat.add_argument('filename', help='local path, http/ipfs URL or "-" (read from stdin)')
     parser_cat.set_defaults(func=cat_command)
+
+    # create the parser for the "edit" command
+    parser_edit = subparsers.add_parser('edit', help='Edit one or more recordings and save the result to a new recording')
+    parser_edit.add_argument('filename', help='filename/path to save the edited recording to')
+    parser_edit.add_argument('-f', '--from-file', help='file(s) to edit', action='append')
+    parser_edit.set_defaults(func=edit_command)
 
     # create the parser for the "upload" command
     parser_upload = subparsers.add_parser('upload', help='Upload locally saved terminal session to asciinema.org')

--- a/asciinema/commands/edit.py
+++ b/asciinema/commands/edit.py
@@ -3,6 +3,13 @@ import asciinema.asciicast as asciicast
 from asciinema.asciicast import v2
 
 
+def edit_events(events, write_event, time_offset=0):
+    for ev in events:
+        ts, etype, data = ev
+        ts += time_offset
+        if etype is not 'd':
+            write_event(ts, etype, data)
+
 class EditCommand(Command):
 
     def __init__(self, source_files, target_file):
@@ -18,10 +25,7 @@ class EditCommand(Command):
                 time_offset = 0
                 for source in self.source_files:
                     with asciicast.open_from_url(source) as cast:
-                        for ev in cast.events():
-                            ts, etype, data = ev
-                            ts += time_offset
-                            target.write_event(ts, etype, data)
+                        edit_events(cast.events(), target.write_event, time_offset)
                     time_offset += v2.get_duration(source)
 
         except asciicast.LoadError as e:

--- a/asciinema/commands/edit.py
+++ b/asciinema/commands/edit.py
@@ -1,5 +1,6 @@
 from asciinema.commands.command import Command
 import asciinema.asciicast as asciicast
+from asciinema.asciicast import v2
 
 
 class EditCommand(Command):
@@ -10,12 +11,21 @@ class EditCommand(Command):
 
     def execute(self):
         try:
-            for source in self.source_files:
-                with asciicast.open_from_url(source) as s:
-                    print(s) 
+            header = None
+            with asciicast.open_from_url(self.source_files[0]) as first_cast:
+                header = first_cast.v2_header()
+            with v2.writer(self.target_file, header=header) as target:
+                offset = 0
+                for source in self.source_files:
+                    with asciicast.open_from_url(source) as cast:
+                        for ev in cast.events():
+                            ts, etype, data = ev
+                            ts += offset
+                            target.write_event(ts, etype, data)
+                        offset += cast.v2_header['duration']
 
         except asciicast.LoadError as e:
-            self.print_error("playback failed: %s" % str(e))
+            self.print_error("loading failed: %s" % str(e))
             return 1
 
         return 0

--- a/asciinema/commands/edit.py
+++ b/asciinema/commands/edit.py
@@ -1,0 +1,21 @@
+from asciinema.commands.command import Command
+import asciinema.asciicast as asciicast
+
+
+class EditCommand(Command):
+
+    def __init__(self, source_files, target_file):
+        self.source_files = source_files
+        self.target_file = target_file
+
+    def execute(self):
+        try:
+            for source in self.source_files:
+                with asciicast.open_from_url(source) as s:
+                    print(s) 
+
+        except asciicast.LoadError as e:
+            self.print_error("playback failed: %s" % str(e))
+            return 1
+
+        return 0

--- a/asciinema/commands/edit.py
+++ b/asciinema/commands/edit.py
@@ -13,16 +13,16 @@ class EditCommand(Command):
         try:
             header = None
             with asciicast.open_from_url(self.source_files[0]) as first_cast:
-                header = first_cast.v2_header()
+                header = first_cast.v2_header
             with v2.writer(self.target_file, header=header) as target:
-                offset = 0
+                time_offset = 0
                 for source in self.source_files:
                     with asciicast.open_from_url(source) as cast:
                         for ev in cast.events():
                             ts, etype, data = ev
-                            ts += offset
+                            ts += time_offset
                             target.write_event(ts, etype, data)
-                        offset += cast.v2_header['duration']
+                    time_offset += v2.get_duration(source)
 
         except asciicast.LoadError as e:
             self.print_error("loading failed: %s" % str(e))

--- a/asciinema/commands/edit.py
+++ b/asciinema/commands/edit.py
@@ -4,11 +4,19 @@ from asciinema.asciicast import v2
 
 
 def edit_events(events, write_event, time_offset=0):
+    result = []
     for ev in events:
         ts, etype, data = ev
         ts += time_offset
-        if etype is not 'd':
-            write_event(ts, etype, data)
+        if etype is 's':
+            result[-1][2] += data
+        elif etype is 'd':
+            pass
+        else:
+            result.append(ev)
+    for ev in result:
+        ts, etype, data = ev
+        write_event(ts, etype, data)
 
 class EditCommand(Command):
 

--- a/asciinema/commands/edit.py
+++ b/asciinema/commands/edit.py
@@ -7,7 +7,6 @@ def edit_events(events, write_event, time_offset=0):
     result = []
     for ev in events:
         ts, etype, data = ev
-        ts += time_offset
         if etype is 's':
             result[-1][2] += data
         elif etype is 'd':
@@ -16,6 +15,7 @@ def edit_events(events, write_event, time_offset=0):
             result.append(ev)
     for ev in result:
         ts, etype, data = ev
+        ts += time_offset
         write_event(ts, etype, data)
 
 class EditCommand(Command):

--- a/tests/edit_test.py
+++ b/tests/edit_test.py
@@ -12,10 +12,36 @@ class TestEdit:
     def write_event(self, ts, etype, data):
         self.events.append([ts, etype, data])
 
-    def test_simple(self):
+    def test_delete(self):
         input_events = [
             [0, "o", "foo"],
             [1, "d", "bar"],
         ]
         edit.edit_events(input_events, self.write_event)
         assert_equal([[0, "o", "foo"]], self.events)
+
+    def test_squash(self):
+        input_events = [
+            [0, "o", "foo"],
+            [1, "s", "bar"],
+            [2, "s", "baz"],
+        ]
+        edit.edit_events(input_events, self.write_event)
+        assert_equal([[0, "o", "foobarbaz"]], self.events)
+
+    def test_delete_and_squash(self):
+        input_events = [
+            [0, "o", "foo"],
+            [1, "d", "XXX"],
+            [2, "s", "bar"],
+            [3, "o", "next"],
+            [4, "s", " baz"]
+        ]
+        expected = [
+            [0, "o", "foobar"],
+            [3, "o", "next baz"],
+        ]
+        edit.edit_events(input_events, self.write_event)
+        assert_equal(expected, self.events)
+
+

--- a/tests/edit_test.py
+++ b/tests/edit_test.py
@@ -1,0 +1,21 @@
+import os
+
+from nose.tools import assert_equal
+from asciinema.commands import edit
+
+
+class TestEdit:
+
+    def setUp(self):
+        self.events = []
+
+    def write_event(self, ts, etype, data):
+        self.events.append([ts, etype, data])
+
+    def test_simple(self):
+        input_events = [
+            [0, "o", "foo"],
+            [1, "d", "bar"],
+        ]
+        edit.edit_events(input_events, self.write_event)
+        assert_equal([[0, "o", "foo"]], self.events)


### PR DESCRIPTION
Fixes #338 

Take one or more asciicast files and edit them manually. Change the event
types as follows,

- "d": delete, this event will be deleted
- "s": squash, this event will be squashed onto the previous one. 
  More consecutive lines can be squashed.

After the individual files are processed, they are concatenated into a single
recording. The times are adjusted, so the last event in the first file is 
immediately followed by the first event in the second file, and so on.