### PR TITLE
Pause/resume recording

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ before_install:
   - pip install pycodestyle
 
 script:
-  - find . -name \*.py -exec pycodestyle --ignore=E501,E402 {} +
+  - find . -name \*.py -exec pycodestyle --ignore=E501,E402,E722 {} +
   - make test

--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ By running `asciinema rec [filename]` you start a new recording session. The
 command (process) that is recorded can be specified with `-c` option (see
 below), and defaults to `$SHELL` which is what you want in most cases.
 
-You can temporarily "mute" recording by pressing <kbd>Ctrl+P</kbd>. This is
-useful when you want to execute some commands during the recording session that
-should not be captured (e.g. pasting secrets). Un-mute by pressing
+You can temporarily pause recording of terminal by pressing <kbd>Ctrl+P</kbd>.
+This is useful when you want to execute some commands during the recording
+session that should not be captured (e.g. pasting secrets). Resume by pressing
 <kbd>Ctrl+P</kbd> again.
 
 Recording finishes when you exit the shell (hit <kbd>Ctrl+D</kbd> or type

--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ By running `asciinema rec [filename]` you start a new recording session. The
 command (process) that is recorded can be specified with `-c` option (see
 below), and defaults to `$SHELL` which is what you want in most cases.
 
+You can temporarily "mute" recording by pressing <kbd>Ctrl+P</kbd>. This is
+useful when you want to execute some commands during the recording session that
+should not be captured (e.g. pasting secrets). Un-mute by pressing
+<kbd>Ctrl+P</kbd> again.
+
 Recording finishes when you exit the shell (hit <kbd>Ctrl+D</kbd> or type
 `exit`). If the recorded process is not a shell then recording finishes when
 the process exits.

--- a/asciinema/__init__.py
+++ b/asciinema/__init__.py
@@ -6,53 +6,20 @@ __version__ = '2.0.2'
 if sys.version_info[0] < 3:
     raise ImportError('Python < 3 is unsupported.')
 
-
-import os
-import subprocess
-import time
-
-import asciinema.asciicast.v2 as v2
-import asciinema.pty as pty
-import asciinema.term as term
+import asciinema.recorder
 
 
 def record_asciicast(path, command=None, append=False, idle_time_limit=None,
                      rec_stdin=False, title=None, metadata=None,
-                     command_env=None, capture_env=None, writer=v2.async_writer,
-                     record=pty.record):
-    if command is None:
-        command = os.environ.get('SHELL') or 'sh'
-
-    if command_env is None:
-        command_env = os.environ.copy()
-        command_env['ASCIINEMA_REC'] = '1'
-
-    if capture_env is None:
-        capture_env = ['SHELL', 'TERM']
-
-    w, h = term.get_size()
-
-    full_metadata = {
-        'width': w,
-        'height': h,
-        'timestamp': int(time.time())
-    }
-
-    full_metadata.update(metadata or {})
-
-    if idle_time_limit is not None:
-        full_metadata['idle_time_limit'] = idle_time_limit
-
-    if capture_env:
-        full_metadata['env'] = {var: command_env.get(var) for var in capture_env}
-
-    if title:
-        full_metadata['title'] = title
-
-    time_offset = 0
-
-    if append and os.stat(path).st_size > 0:
-        time_offset = v2.get_duration(path)
-
-    with writer(path, full_metadata, append, time_offset) as w:
-        record(['sh', '-c', command], w, command_env, rec_stdin)
+                     command_env=None, capture_env=None):
+    asciinema.recorder.record(
+        path,
+        command=command,
+        append=append,
+        idle_time_limit=idle_time_limit,
+        rec_stdin=rec_stdin,
+        title=title,
+        metadata=metadata,
+        command_env=command_env,
+        capture_env=capture_env
+    )

--- a/asciinema/asciicast/raw.py
+++ b/asciinema/asciicast/raw.py
@@ -1,39 +1,25 @@
 import os
-from multiprocessing import Process, Queue
-
-
-def write_bytes_from_queue(path, mode, queue):
-    mode = mode + 'b'
-
-    with open(path, mode=mode, buffering=0) as f:
-        for data in iter(queue.get, None):
-            f.write(data)
 
 
 class writer():
 
-    def __init__(self, path, _metadata, append=False, _time_offset=0):
+    def __init__(self, path, metadata=None, append=False, buffering=0):
         if append and os.path.exists(path) and os.stat(path).st_size == 0:  # true for pipes
             append = False
 
         self.path = path
-        self.mode = 'a' if append else 'w'
-        self.queue = Queue()
+        self.buffering = buffering
+        self.mode = 'ab' if append else 'wb'
 
     def __enter__(self):
-        self.process = Process(
-            target=write_bytes_from_queue,
-            args=(self.path, self.mode, self.queue)
-        )
-        self.process.start()
+        self.file = open(self.path, mode=self.mode, buffering=self.buffering)
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.queue.put(None)
-        self.process.join()
+        self.file.close()
+
+    def write_stdout(self, ts, data):
+        self.file.write(data)
 
     def write_stdin(self, ts, data):
         pass
-
-    def write_stdout(self, ts, data):
-        self.queue.put(data)

--- a/asciinema/asciicast/raw.py
+++ b/asciinema/asciicast/raw.py
@@ -32,8 +32,8 @@ class writer():
         self.queue.put(None)
         self.process.join()
 
-    def write_stdin(self, data):
+    def write_stdin(self, ts, data):
         pass
 
-    def write_stdout(self, data):
+    def write_stdout(self, ts, data):
         self.queue.put(data)

--- a/asciinema/asciicast/v2.py
+++ b/asciinema/asciicast/v2.py
@@ -176,17 +176,16 @@ class async_writer():
             args=(self.path, header, mode, self.queue)
         )
         self.process.start()
-        self.start_time = time.time() - self.time_offset
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.queue.put(None)
         self.process.join()
 
-    def write_stdin(self, data):
-        ts = time.time() - self.start_time
+    def write_stdin(self, ts, data):
+        ts = ts + self.time_offset
         self.queue.put([ts, 'i', data])
 
-    def write_stdout(self, data):
-        ts = time.time() - self.start_time
+    def write_stdout(self, ts, data):
+        ts = ts + self.time_offset
         self.queue.put([ts, 'o', data])

--- a/asciinema/asciicast/v2.py
+++ b/asciinema/asciicast/v2.py
@@ -94,7 +94,7 @@ def build_header(metadata):
 
 class writer():
 
-    def __init__(self, path, width=None, height=None, header=None, append=False, buffering=-1):
+    def __init__(self, path, width=None, height=None, header=None, append=False, buffering=1):
         self.path = path
         self.buffering = buffering
         self.stdin_decoder = codecs.getincrementaldecoder('UTF-8')('replace')
@@ -152,7 +152,7 @@ class writer():
 
 
 def write_json_lines_from_queue(path, header, append, queue):
-    with writer(path, header=header, append=append, buffering=1) as w:
+    with writer(path, header=header, append=append) as w:
         for event in iter(queue.get, None):
             w.write_event(event)
 

--- a/asciinema/async_worker.py
+++ b/asciinema/async_worker.py
@@ -1,0 +1,31 @@
+try:
+    # Importing synchronize is to detect platforms where
+    # multiprocessing does not work (python issue 3770)
+    # and cause an ImportError. Otherwise it will happen
+    # later when trying to use Queue().
+    from multiprocessing import synchronize, Process, Queue
+except ImportError:
+    from threading import Thread as Process
+    from queue import Queue
+
+
+class async_worker():
+
+    def __init__(self):
+        self.queue = Queue()
+
+    def __enter__(self):
+        self.process = Process(target=self.run)
+        self.process.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.queue.put(None)
+        self.process.join()
+
+    def enqueue(self, payload):
+        self.queue.put(payload)
+
+    def run(self):
+        for payload in iter(self.queue.get, None):
+            self.perform(payload)

--- a/asciinema/commands/record.py
+++ b/asciinema/commands/record.py
@@ -2,7 +2,7 @@ import os
 import sys
 import tempfile
 
-import asciinema
+import asciinema.recorder as recorder
 import asciinema.asciicast.raw as raw
 import asciinema.asciicast.v2 as v2
 from asciinema.api import APIError
@@ -24,7 +24,7 @@ class RecordCommand(Command):
         self.append = args.append
         self.overwrite = args.overwrite
         self.raw = args.raw
-        self.writer = raw.writer if args.raw else v2.async_writer
+        self.writer = raw.writer if args.raw else v2.writer
         self.env = env if env is not None else os.environ
 
     def execute(self):
@@ -66,7 +66,7 @@ class RecordCommand(Command):
         vars = filter(None, map((lambda var: var.strip()), self.env_whitelist.split(',')))
 
         try:
-            asciinema.record_asciicast(
+            recorder.record(
                 self.filename,
                 command=self.command,
                 append=append,

--- a/asciinema/notifier.py
+++ b/asciinema/notifier.py
@@ -1,0 +1,31 @@
+import shutil
+import subprocess
+
+
+class Notifier():
+    def is_available(self):
+        return shutil.which(self.cmd) is not None
+
+
+class AppleScriptNotifier(Notifier):
+    cmd = "osascript"
+
+    def notify(self, text):
+        cmd = 'osascript -e \'display notification "{}" with title "asciinema"\''.format(text)
+        subprocess.run(["/bin/sh", "-c", cmd], capture_output=True)
+        # we don't want to print *ANYTHING* to the terminal
+        # so we capture and ignore all output
+
+
+class NoopNotifier():
+    def notify(self, text):
+        pass
+
+
+def get_notifier():
+    n = AppleScriptNotifier()
+
+    if n.is_available():
+        return n
+
+    return NoopNotifier()

--- a/asciinema/pty.py
+++ b/asciinema/pty.py
@@ -15,7 +15,7 @@ import time
 from asciinema.term import raw
 
 
-def record(command, writer, env=os.environ, rec_stdin=False):
+def record(command, writer, env=os.environ, rec_stdin=False, time_offset=0):
     master_fd = None
     start_time = None
 
@@ -131,7 +131,7 @@ def record(command, writer, env=os.environ, rec_stdin=False):
 
     _set_pty_size()
 
-    start_time = time.time()
+    start_time = time.time() - time_offset
 
     with raw(pty.STDIN_FILENO):
         try:

--- a/asciinema/pty.py
+++ b/asciinema/pty.py
@@ -60,7 +60,7 @@ def record(command, writer, env=os.environ, rec_stdin=False, time_offset=0):
 
         nonlocal muted
 
-        if data == b'\x10': # ctrl+p
+        if data == b'\x10':  # ctrl+p
             muted = not muted
         else:
             _write_master(data)

--- a/asciinema/pty.py
+++ b/asciinema/pty.py
@@ -15,10 +15,14 @@ import time
 from asciinema.term import raw
 
 
-def record(command, writer, env=os.environ, rec_stdin=False, time_offset=0):
+def record(command, writer, env=os.environ, rec_stdin=False, time_offset=0, notifier=None):
     master_fd = None
     start_time = None
     pause_time = None
+
+    def _notify(text):
+        if notifier:
+            notifier.notify(text)
 
     def _set_pty_size():
         '''
@@ -65,8 +69,10 @@ def record(command, writer, env=os.environ, rec_stdin=False, time_offset=0):
             if pause_time:
                 start_time = start_time + (time.time() - pause_time)
                 pause_time = None
+                _notify('Resumed recording')
             else:
                 pause_time = time.time()
+                _notify('Paused recording')
         else:
             _write_master(data)
 

--- a/asciinema/pty.py
+++ b/asciinema/pty.py
@@ -18,7 +18,7 @@ from asciinema.term import raw
 def record(command, writer, env=os.environ, rec_stdin=False, time_offset=0):
     master_fd = None
     start_time = None
-    muted = False
+    paused = False
 
     def _set_pty_size():
         '''
@@ -43,7 +43,7 @@ def record(command, writer, env=os.environ, rec_stdin=False, time_offset=0):
     def _handle_master_read(data):
         '''Handles new data on child process stdout.'''
 
-        if not muted:
+        if not paused:
             writer.write_stdout(time.time() - start_time, data)
 
         _write_stdout(data)
@@ -58,14 +58,14 @@ def record(command, writer, env=os.environ, rec_stdin=False, time_offset=0):
     def _handle_stdin_read(data):
         '''Handles new data on child process stdin.'''
 
-        nonlocal muted
+        nonlocal paused
 
         if data == b'\x10':  # ctrl+p
-            muted = not muted
+            paused = not paused
         else:
             _write_master(data)
 
-            if rec_stdin and not muted:
+            if rec_stdin and not paused:
                 writer.write_stdin(time.time() - start_time, data)
 
     def _signals(signal_list):

--- a/asciinema/recorder.py
+++ b/asciinema/recorder.py
@@ -1,0 +1,102 @@
+import os
+import time
+
+try:
+    # Importing synchronize is to detect platforms where
+    # multiprocessing does not work (python issue 3770)
+    # and cause an ImportError. Otherwise it will happen
+    # later when trying to use Queue().
+    from multiprocessing import synchronize, Process, Queue
+except ImportError:
+    from threading import Thread as Process
+    from queue import Queue
+
+import asciinema.asciicast.v2 as v2
+import asciinema.pty as pty
+import asciinema.term as term
+
+
+def record(path, command=None, append=False, idle_time_limit=None,
+           rec_stdin=False, title=None, metadata=None, command_env=None,
+           capture_env=None, writer=v2.writer, record=pty.record):
+    if command is None:
+        command = os.environ.get('SHELL') or 'sh'
+
+    if command_env is None:
+        command_env = os.environ.copy()
+        command_env['ASCIINEMA_REC'] = '1'
+
+    if capture_env is None:
+        capture_env = ['SHELL', 'TERM']
+
+    w, h = term.get_size()
+
+    full_metadata = {
+        'width': w,
+        'height': h,
+        'timestamp': int(time.time())
+    }
+
+    full_metadata.update(metadata or {})
+
+    if idle_time_limit is not None:
+        full_metadata['idle_time_limit'] = idle_time_limit
+
+    if capture_env:
+        full_metadata['env'] = {var: command_env.get(var) for var in capture_env}
+
+    if title:
+        full_metadata['title'] = title
+
+    time_offset = 0
+
+    if append and os.stat(path).st_size > 0:
+        time_offset = v2.get_duration(path)
+
+    with async_writer(writer, path, full_metadata, append, time_offset) as w:
+        record(['sh', '-c', command], w, command_env, rec_stdin)
+
+
+def write_events_from_queue(writer, path, metadata, append, queue):
+    with writer(path, metadata=metadata, append=append) as w:
+        for event in iter(queue.get, None):
+            ts, etype, data = event
+
+            if etype == 'o':
+                w.write_stdout(ts, data)
+            elif etype == 'i':
+                w.write_stdin(ts, data)
+
+
+class async_writer():
+
+    def __init__(self, writer, path, metadata, append=False, time_offset=0):
+        if append:
+            assert time_offset > 0
+
+        self.writer = writer
+        self.path = path
+        self.metadata = metadata
+        self.append = append
+        self.time_offset = time_offset
+        self.queue = Queue()
+
+    def __enter__(self):
+        self.process = Process(
+            target=write_events_from_queue,
+            args=(self.writer, self.path, self.metadata, self.append, self.queue)
+        )
+        self.process.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.queue.put(None)
+        self.process.join()
+
+    def write_stdin(self, ts, data):
+        ts = ts + self.time_offset
+        self.queue.put([ts, 'i', data])
+
+    def write_stdout(self, ts, data):
+        ts = ts + self.time_offset
+        self.queue.put([ts, 'o', data])

--- a/man/asciinema.1.md
+++ b/man/asciinema.1.md
@@ -35,6 +35,11 @@ By running **asciinema rec [filename]** you start a new recording session. The
 command (process) that is recorded can be specified with **-c** option (see
 below), and defaults to **$SHELL** which is what you want in most cases.
 
+You can temporarily "mute" recording by pressing <kbd>Ctrl+P</kbd>. This is
+useful when you want to execute some commands during the recording session that
+should not be captured (e.g. pasting secrets). Un-mute by pressing
+<kbd>Ctrl+P</kbd> again.
+
 Recording finishes when you exit the shell (hit <kbd>Ctrl+D</kbd> or type
 `exit`). If the recorded process is not a shell then recording finishes when
 the process exits.

--- a/man/asciinema.1.md
+++ b/man/asciinema.1.md
@@ -35,9 +35,9 @@ By running **asciinema rec [filename]** you start a new recording session. The
 command (process) that is recorded can be specified with **-c** option (see
 below), and defaults to **$SHELL** which is what you want in most cases.
 
-You can temporarily "mute" recording by pressing <kbd>Ctrl+P</kbd>. This is
-useful when you want to execute some commands during the recording session that
-should not be captured (e.g. pasting secrets). Un-mute by pressing
+You can temporarily pause recording of terminal by pressing <kbd>Ctrl+P</kbd>.
+This is useful when you want to execute some commands during the recording
+session that should not be captured (e.g. pasting secrets). Resume by pressing
 <kbd>Ctrl+P</kbd> again.
 
 Recording finishes when you exit the shell (hit <kbd>Ctrl+D</kbd> or type

--- a/tests/pty_test.py
+++ b/tests/pty_test.py
@@ -12,10 +12,10 @@ class FakeStdout:
     def __init__(self):
         self.data = []
 
-    def write_stdout(self, data):
+    def write_stdout(self, ts, data):
         self.data.append(data)
 
-    def write_stdin(self, data):
+    def write_stdin(self, ts, data):
         pass
 
 


### PR DESCRIPTION
This one adds recording pausing/resuming functionality, that can be used to temporarily turn off capturing of stdout/stdin by pressing a hotkey. This is useful when you want to execute commands during the recording session that should not be captured (e.g. pasting secrets).

Similarly to #341, the hotkey for toggling pause is hard-coded at the moment to `ctrl+p` ("p" for "pause capture"), but it is very likely to conflict with many interactive applications (e.g. vim), so we may want to find a better one, or go with a prefix + key (like `ctrl+a <key>` in `screen`, `ctrl+b  <key>` in `tmux`).

It may be a good idea to show a notification that pause/resume actually happened after pressing a hotkey. Printing something to the terminal is not a good idea here, since it would potentially overwrite whatever was printed before (in fullscreen apps like vim), so I believe an external tool is the best choice. We could have a setting in a config file `notification_command` which would be invoked to notify about pause/resume (also about setting breakpoint in #341). You could then set it to show the notification in tmux's status bar (via `tmux display-message`) or show a desktop notification (`notify-send`, Growl, etc) or play a sound.

- [x] toggle pause during recording session via hotkey
- [x] stop time when paused
- [x] documentation
- [ ] notifications
- [ ] find good default hotkey, and/or hotkey prefix (like GNU screen, tmux)
