### PR TITLE
Breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ pause_key = p
 ; default: . (dot)
 step_key = s
 
-; Define hotkey for jumping to next breakpoint,
+; Define hotkey for jumping to the next breakpoint,
 ; default: ]
 next_breakpoint_key = b
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Available options:
 - `-i, --idle-time-limit=<sec>` - Limit replayed terminal inactivity to max `<sec>` seconds
 - `-s, --speed=<factor>` - Playback speed (can be fractional)
 - `-l, --loop` - Play in a loop
+- `-b, --breakpoints` - Automatically pause on [breakpoints](#breakpoints)
 - `--stream=<stream>` - Select stream to play (see below)
 - `--out-fmt=<format>` - Select output format (see below)
 
@@ -361,6 +362,29 @@ happen in any order.
 > asciinema versions prior to 2.0 confusingly referred to install ID as "API
 > token".
 
+## Breakpoints
+
+Breakpoints are markers that you can set in a recording to pause the playback at
+a specific point.
+
+When a breakpoint is reached, the playback automatically pauses and can be
+resumed by pressing space bar key. The playback continues until next breakpoint
+is encountered.
+
+To enable auto-pause-on-breakpoint behaviour when replaying with `asciinema
+play` use `-b`/`--breakpoints` option. It's off by default.
+
+Breakpoints can be added to a recording in several ways:
+
+- during recording session, by pressing a configured hotkey, see
+  [add_breakpoint_key config option](#configuration-file)
+- for existing recording, by inserting breakpoint events (`"b"`) in the
+  asciicast file, see [breakpoint event](doc/asciicast-v2.md#b---breakpoint)
+
+Breakpoints can be useful in e.g. live demos: you can create a recording with
+breakpoints, then play it back during presentation, and have it stop wherever
+you want to explain terminal contents in more detail.
+
 ## Hosting the recordings on the web
 
 As mentioned in the `Usage > rec` section above, if the `filename` argument to
@@ -419,7 +443,7 @@ quiet = true
 ; default: C-\ (control + backslash)
 pause_key = C-p
 
-; Define hotkey for adding a breakpoint, default: None
+; Define hotkey for adding a breakpoint, default: none
 add_breakpoint_key = C-b
 
 ; Define hotkey prefix key - when defined other recording hotkeys must

--- a/README.md
+++ b/README.md
@@ -419,6 +419,9 @@ quiet = true
 ; default: C-\ (control + backslash)
 pause_key = C-p
 
+; Define hotkey for adding a breakpoint, default: None
+add_breakpoint_key = C-b
+
 ; Define hotkey prefix key - when defined other recording hotkeys must
 ; be preceeded by it, default: no prefix
 prefix_key = C-a

--- a/README.md
+++ b/README.md
@@ -381,6 +381,9 @@ Breakpoints can be added to a recording in several ways:
 - for existing recording, by inserting breakpoint events (`"b"`) in the
   asciicast file, see [breakpoint event](doc/asciicast-v2.md#b---breakpoint)
 
+When replaying a recording with `asciinema play` you can fast-forward to the
+next breakpoint by pressing `]` key (when paused).
+
 Breakpoints can be useful in e.g. live demos: you can create a recording with
 breakpoints, then play it back during presentation, and have it stop wherever
 you want to explain terminal contents in more detail.
@@ -463,8 +466,12 @@ idle_time_limit = 1
 pause_key = p
 
 ; Define hotkey for stepping through playback, a frame at a time,
-; default: .
-step_key = ]
+; default: . (dot)
+step_key = s
+
+; Define hotkey for jumping to next breakpoint,
+; default: ]
+next_breakpoint_key = b
 
 [notifications]
 ; Desktop notifications are displayed on certain occasions, e.g. when

--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -197,6 +197,13 @@ For help on a specific command run:
         default=False,
     )
     parser_play.add_argument(
+        "-b",
+        "--breakpoints",
+        help="automatically pause on breakpoints",
+        action="store_true",
+        default=False,
+    )
+    parser_play.add_argument(
         "--out-fmt",
         help="select output format",
         choices=["raw", "asciicast"],

--- a/asciinema/asciicast/raw.py
+++ b/asciinema/asciicast/raw.py
@@ -33,6 +33,9 @@ class writer(file_writer):
     def write_stdin(self, ts: float, data: Any) -> None:
         pass
 
+    def write_breakpoint(self, ts: float) -> None:
+        pass
+
     # pylint: disable=consider-using-with
     def _open_file(self) -> None:
         if self.path == "-":

--- a/asciinema/asciicast/v2.py
+++ b/asciinema/asciicast/v2.py
@@ -145,6 +145,9 @@ class writer(file_writer):
         data = self.stdin_decoder.decode(data)
         self.__write_event(ts, "i", data)
 
+    def write_breakpoint(self, ts: float) -> None:
+        self.__write_event(ts, "b", "")
+
     # pylint: disable=consider-using-with
     def _open_file(self) -> None:
         if self.path == "-":

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -26,6 +26,7 @@ class PlayCommand(Command):
         self.key_bindings = {
             "pause": config.play_pause_key,
             "step": config.play_step_key,
+            "next_breakpoint": config.play_next_breakpoint_key,
         }
 
     def execute(self) -> int:

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -21,6 +21,7 @@ class PlayCommand(Command):
         self.loop = args.loop
         self.out_fmt = args.out_fmt
         self.stream = args.stream
+        self.breakpoints = args.breakpoints
         self.player = player if player is not None else Player()
         self.key_bindings = {
             "pause": config.play_pause_key,
@@ -46,6 +47,7 @@ class PlayCommand(Command):
                     key_bindings=self.key_bindings,
                     out_fmt=self.out_fmt,
                     stream=self.stream,
+                    pause_on_breakpoints=self.breakpoints,
                 )
 
         except asciicast.LoadError as e:

--- a/asciinema/commands/record.py
+++ b/asciinema/commands/record.py
@@ -34,6 +34,7 @@ class RecordCommand(Command):  # pylint: disable=too-many-instance-attributes
         self.key_bindings = {
             "prefix": config.record_prefix_key,
             "pause": config.record_pause_key,
+            "add_breakpoint": config.record_add_breakpoint_key,
         }
 
     # pylint: disable=too-many-branches

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -137,6 +137,10 @@ class Config:
         return self.__get_key("record", "pause", "C-\\")
 
     @property
+    def record_add_breakpoint_key(self) -> Any:
+        return self.__get_key("record", "add_breakpoint")
+
+    @property
     def play_idle_time_limit(self) -> Optional[float]:
         fallback = self.config.getfloat(
             "play", "maxwait", fallback=None

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -162,6 +162,10 @@ class Config:
         return self.__get_key("play", "step", ".")
 
     @property
+    def play_next_breakpoint_key(self) -> Any:
+        return self.__get_key("play", "next_breakpoint", "]")
+
+    @property
     def notifications_enabled(self) -> bool:
         return self.config.getboolean(
             "notifications", "enabled", fallback=True

--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -101,6 +101,7 @@ class Player:  # pylint: disable=too-few-public-methods
         idle_time_limit = idle_time_limit or asciicast.idle_time_limit
         pause_key = key_bindings.get("pause")
         step_key = key_bindings.get("step")
+        next_breakpoint_key = key_bindings.get("next_breakpoint")
 
         events = asciicast.events()
         events = ev.to_relative_time(events)
@@ -148,6 +149,16 @@ class Player:  # pylint: disable=too-few-public-methods
                         pause_elapsed_time = time_
                         output.write(time_, event_type, text)
                         time_, event_type, text = next_event()
+
+                    elif key == next_breakpoint_key:
+                        while time_ is not None and event_type != "b":
+                            output.write(time_, event_type, text)
+                            time_, event_type, text = next_event()
+
+                        if time_ is not None:
+                            output.write(time_, event_type, text)
+                            pause_elapsed_time = time_
+                            time_, event_type, text = next_event()
             else:
                 while time_ is not None:
                     elapsed_wall_time = time.time() - start_time

--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -73,7 +73,6 @@ class Player:  # pylint: disable=too-few-public-methods
                         speed,
                         stdin,
                         key_bindings,
-                        stream,
                         output,
                     )
         except Exception:  # pylint: disable=broad-except
@@ -83,7 +82,6 @@ class Player:  # pylint: disable=too-few-public-methods
                 speed,
                 None,
                 key_bindings,
-                stream,
                 output,
             )
 
@@ -94,7 +92,6 @@ class Player:  # pylint: disable=too-few-public-methods
         speed: float,
         stdin: Optional[TextIO],
         key_bindings: Dict[str, Any],
-        stream: Optional[str],
         output: Output,
     ) -> None:
         idle_time_limit = idle_time_limit or asciicast.idle_time_limit

--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -75,7 +75,7 @@ class Player:  # pylint: disable=too-few-public-methods
                         key_bindings,
                         output,
                     )
-        except Exception:  # pylint: disable=broad-except
+        except IOError:
             self._play(
                 asciicast,
                 idle_time_limit,

--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -56,6 +56,7 @@ class Player:  # pylint: disable=too-few-public-methods
         key_bindings: Optional[Dict[str, Any]] = None,
         out_fmt: str = "raw",
         stream: Optional[str] = None,
+        pause_on_breakpoints: bool = False,
     ) -> None:
         if key_bindings is None:
             key_bindings = {}
@@ -74,6 +75,7 @@ class Player:  # pylint: disable=too-few-public-methods
                         stdin,
                         key_bindings,
                         output,
+                        pause_on_breakpoints,
                     )
         except IOError:
             self._play(
@@ -83,6 +85,7 @@ class Player:  # pylint: disable=too-few-public-methods
                 None,
                 key_bindings,
                 output,
+                False,
             )
 
     @staticmethod
@@ -93,6 +96,7 @@ class Player:  # pylint: disable=too-few-public-methods
         stdin: Optional[TextIO],
         key_bindings: Dict[str, Any],
         output: Output,
+        pause_on_breakpoints: bool,
     ) -> None:
         idle_time_limit = idle_time_limit or asciicast.idle_time_limit
         pause_key = key_bindings.get("pause")
@@ -152,5 +156,5 @@ class Player:  # pylint: disable=too-few-public-methods
 
             output.write(time_, event_type, text)
 
-            if event_type == "b":
+            if event_type == "b" and pause_on_breakpoints:
                 pause_elapsed_time = time_

--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -113,9 +113,9 @@ class Player:  # pylint: disable=too-few-public-methods
         for time_, event_type, text in events:
             elapsed_wall_time = time.time() - start_time
             delay = time_ - elapsed_wall_time
-            sleep = delay > 0
+            wait = delay > 0 or pause_elapsed_time
 
-            while stdin and sleep and not ctrl_c:
+            while stdin and wait and not ctrl_c:
                 if pause_elapsed_time:
                     while True:
                         data = read_blocking(stdin.fileno(), 1000)
@@ -132,7 +132,7 @@ class Player:  # pylint: disable=too-few-public-methods
 
                         if data == step_key:
                             pause_elapsed_time = time_
-                            sleep = False
+                            wait = False
                             break
                 else:
                     data = read_blocking(stdin.fileno(), delay)
@@ -151,3 +151,6 @@ class Player:  # pylint: disable=too-few-public-methods
                 raise KeyboardInterrupt()
 
             output.write(time_, event_type, text)
+
+            if event_type == "b":
+                pause_elapsed_time = time_

--- a/asciinema/pty_.py
+++ b/asciinema/pty_.py
@@ -77,7 +77,7 @@ def record(
             elif data == add_breakpoint_key:
                 assert start_time is not None
                 writer.write_breakpoint(time.time() - start_time)
-                notify("Added breakpoint")
+                notify("Breakpoint added")
 
             return
 

--- a/asciinema/pty_.py
+++ b/asciinema/pty_.py
@@ -36,6 +36,7 @@ def record(
     prefix_mode: bool = False
     prefix_key = key_bindings.get("prefix")
     pause_key = key_bindings.get("pause")
+    add_breakpoint_key = key_bindings.get("add_breakpoint")
 
     def set_pty_size() -> None:
         cols, rows = get_tty_size()
@@ -58,7 +59,9 @@ def record(
             prefix_mode = True
             return
 
-        if prefix_mode or (not prefix_key and data in [pause_key]):
+        if prefix_mode or (
+            not prefix_key and data in [pause_key, add_breakpoint_key]
+        ):
             prefix_mode = False
 
             if data == pause_key:
@@ -70,6 +73,11 @@ def record(
                 else:
                     pause_time = time.time()
                     notify("Paused recording")
+
+            elif data == add_breakpoint_key:
+                assert start_time is not None
+                writer.write_breakpoint(time.time() - start_time)
+                notify("Added breakpoint")
 
             return
 

--- a/asciinema/recorder.py
+++ b/asciinema/recorder.py
@@ -131,6 +131,9 @@ class async_writer(async_worker):
     def write_stdout(self, ts: float, data: Any) -> None:
         self.enqueue([ts, "o", data])
 
+    def write_breakpoint(self, ts: float) -> None:
+        self.enqueue([ts, "b", None])
+
     def run(self) -> None:
         try:
             with self.writer as w:
@@ -143,6 +146,8 @@ class async_writer(async_worker):
                         w.write_stdout(self.time_offset + ts, data)
                     elif etype == "i":
                         w.write_stdin(self.time_offset + ts, data)
+                    elif etype == "b":
+                        w.write_breakpoint(self.time_offset + ts)
         except IOError:
             for event in iter(self.queue.get, None):
                 pass

--- a/doc/asciicast-v2.md
+++ b/doc/asciicast-v2.md
@@ -173,8 +173,8 @@ When breakpoint is encountered in the event stream and "pause on breakpoint"
 functionality of the player is enabled, the playback should pause, and wait for
 the user to resume.
 
-`event-data` can be used to annotate (comment) a breakpoint. Annotations may be
-used to e.g. show a list of named "chapters".
+`event-data` can be used to annotate a breakpoint. Annotations may be used to
+e.g. show a list of named "chapters".
 
 ## Notes on compatibility
 

--- a/doc/asciicast-v2.md
+++ b/doc/asciicast-v2.md
@@ -167,15 +167,14 @@ non-printable Unicode codepoints encoded as `\uXXXX`.
 
 #### "b" - breakpoint
 
-Event of type `"b"` represents a playback breakpoint.
+Event of type `"b"` represents a breakpoint.
 
 When breakpoint is encountered in the event stream and "pause on breakpoint"
 functionality of the player is enabled, the playback should pause, and wait for
 the user to resume.
 
 `event-data` can be used to annotate (comment) a breakpoint. Annotations may be
-used to show a list of "chapters" (players that load whole recording into
-memory only).
+used to e.g. show a list of "chapters".
 
 ## Notes on compatibility
 

--- a/doc/asciicast-v2.md
+++ b/doc/asciicast-v2.md
@@ -174,7 +174,7 @@ functionality of the player is enabled, the playback should pause, and wait for
 the user to resume.
 
 `event-data` can be used to annotate (comment) a breakpoint. Annotations may be
-used to e.g. show a list of "chapters".
+used to e.g. show a list of named "chapters".
 
 ## Notes on compatibility
 

--- a/doc/asciicast-v2.md
+++ b/doc/asciicast-v2.md
@@ -13,7 +13,8 @@ Example file:
 {"version": 2, "width": 80, "height": 24, "timestamp": 1504467315, "title": "Demo", "env": {"TERM": "xterm-256color", "SHELL": "/bin/zsh"}}
 [0.248848, "o", "\u001b[1;31mHello \u001b[32mWorld!\u001b[0m\n"]
 [1.001376, "o", "That was ok\rThis is better."]
-[2.143733, "o", " "]
+[1.500000, "b", ""]
+[2.143733, "o", "Now... "]
 [6.541828, "o", "Bye!"]
 ```
 
@@ -114,7 +115,7 @@ Where:
 
 * `time` (float) - indicates when this event happened, represented as the number
   of seconds since the beginning of the recording session,
-* `event-type` (string) - one of: `"o"`, `"i"`,
+* `event-type` (string) - one of: `"o"`, `"i"`, `"b"`
 * `event-data` (any) - event specific data, described separately for each event
   type.
 
@@ -163,6 +164,18 @@ non-printable Unicode codepoints encoded as `\uXXXX`.
 > Official asciinema recorder doesn't capture keyboard input by default. All
 > implementations of asciicast-compatible terminal recorder should not capture
 > it either unless explicitly permitted by the user.
+
+#### "b" - breakpoint
+
+Event of type `"b"` represents a playback breakpoint.
+
+When breakpoint is encountered in the event stream and "pause on breakpoint"
+functionality of the player is enabled, the playback should pause, and wait for
+the user to resume.
+
+`event-data` can be used to annotate (comment) a breakpoint. Annotations may be
+used to show a list of "chapters" (players that load whole recording into
+memory only).
 
 ## Notes on compatibility
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -100,5 +100,5 @@ asciinema rec --append -c uptime "${TMP_DATA_DIR}/7.cast"
 
 # adding a breakpoint
 printf "[record]\nadd_breakpoint_key = C-b\n" >> "${ASCIINEMA_CONFIG_HOME}/config"
-(sh -c "sleep 1; printf '.'; sleep 0.5; printf '\x08'; sleep 0.5; printf '\x02'; sleep 0.5; printf '\x04'") | asciinema rec -c /bin/sh "${TMP_DATA_DIR}/8.cast"
+(bash -c "sleep 1; printf '.'; sleep 0.5; printf '\x08'; sleep 0.5; printf '\x02'; sleep 0.5; printf '\x04'") | asciinema rec -c /bin/bash "${TMP_DATA_DIR}/8.cast"
 grep '"b",' "${TMP_DATA_DIR}/8.cast"

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -23,6 +23,10 @@ asciinema() {
     python3 -m asciinema "${@}"
 }
 
+## disable notifications
+
+printf "[notifications]\nenabled = no\n" >> "${ASCIINEMA_CONFIG_HOME}/config"
+
 ## test help message
 
 asciinema -h
@@ -93,3 +97,8 @@ asciinema rec --raw -c 'bash -c "echo t3st; sleep 1; echo ok"' "${TMP_DATA_DIR}/
 # appending to existing recording
 asciinema rec -c 'echo allright!; sleep 0.1' "${TMP_DATA_DIR}/7.cast"
 asciinema rec --append -c uptime "${TMP_DATA_DIR}/7.cast"
+
+# adding a breakpoint
+printf "[record]\nadd_breakpoint_key = C-b\n" >> "${ASCIINEMA_CONFIG_HOME}/config"
+(sh -c "sleep 1; printf '.'; sleep 0.5; printf '\x08'; sleep 0.5; printf '\x02'; sleep 0.5; printf '\x04'") | asciinema rec -c /bin/sh "${TMP_DATA_DIR}/8.cast"
+grep '"b",' "${TMP_DATA_DIR}/8.cast"


### PR DESCRIPTION
This one adds breakpoints - locations in the recording which allow the player to auto-pause when one is encountered.

A breakpoint is new `"b"` event type in asciicast stream, with optional annotation (comment) as event data.

To add a breakpoint during recording session press a hotkey (specified in config file as `add_breakpoint_key`).

To add breakpoints to existing recording you add `"b"` events like this:

```
...
[1.000000, "o", "some text"]
[2.500000, "b", ""]
[3.750000, "o", "more text"]
[4.500000, "b", "chapter 5"]
...
```

- [x] support for breakpoints in asciicast v2 event stream
- [x] setting breakpoint during recording session via hotkey
- [x] documentation
- [x] ~~find good default hotkey, and/or hotkey prefix (like GNU screen, tmux)~~ no default for now
- [x] implement pause-on-breakpoint mode for `asciinema play` command (opt-in with `-b/--breakpoints` switch)
- [x] jump to next breakpoint during `asciinema play` with hotkey (`]`)
- [x] add test