### PR TITLE
edit upload .cast file url

### DIFF
--- a/asciinema/api.py
+++ b/asciinema/api.py
@@ -27,7 +27,7 @@ class Api:
         return "{}/connect/{}".format(self.url, self.install_id)
 
     def upload_url(self):
-        return "{}/api/asciicasts".format(self.url)
+        return "{}/api/asciicasts/".format(self.url)
 
     def upload_asciicast(self, path):
         with open(path, 'rb') as f:


### PR DESCRIPTION
Some http servers such as nginx, will return a 301 redirect , when you post to a url not ended with / . 

When Post To  /asciinema/api/asciicasts , 
It will return  : 
301 /asciinema/api/asciicasts/ ,