### PR TITLE
Check playback size can fit in terminal

### DIFF
--- a/asciinema/asciicast/v1.py
+++ b/asciinema/asciicast/v1.py
@@ -34,6 +34,9 @@ class Asciicast:
     def events(self):
         return self.stdout_events()
 
+    def get_size(self):
+        return (int(self.v2_header['width']), int(self.v2_header['height']))
+
     def stdout_events(self):
         return to_absolute_time(self.__stdout_events())
 

--- a/asciinema/asciicast/v2.py
+++ b/asciinema/asciicast/v2.py
@@ -25,6 +25,9 @@ class Asciicast:
         for line in self.__file:
             yield json.loads(line)
 
+    def get_size(self):
+        return (int(self.v2_header['width']), int(self.v2_header['height']))
+
     def stdout_events(self):
         for time, type, data in self.events():
             if type == 'o':

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -21,7 +21,8 @@ class PlayCommand(Command):
                 if play_w < rec_w or play_h < rec_h:
                     self.print_warning("Terminal size is smaller than recording")
                     self.print_warning("Playback may not be displayed as intended")
-                    self.print_warning('Trying making terminal at least {} x {} in size'.format(rec_w, rec_h))
+                    self.print_warning('The current terminal is {} x {} in size'.format(play_w, play_h))
+                    self.print_warning('Try making the terminal at least {} x {} in size'.format(rec_w, rec_h))
 
                 self.player.play(a, self.idle_time_limit, self.speed)
 

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -1,6 +1,7 @@
 from asciinema.commands.command import Command
 from asciinema.player import Player
 import asciinema.asciicast as asciicast
+import asciinema.term as term
 
 
 class PlayCommand(Command):
@@ -15,6 +16,13 @@ class PlayCommand(Command):
     def execute(self):
         try:
             with asciicast.open_from_url(self.filename) as a:
+                play_w, play_h = term.get_size()
+                rec_w, rec_h = a.get_size()
+                if play_w < rec_w or play_h < rec_h:
+                    self.print_warning("Terminal size is smaller than recording")
+                    self.print_warning("Playback may not be displayed as intended")
+                    self.print_warning('Trying making terminal at least {} x {} in size'.format(rec_w, rec_h))
+
                 self.player.play(a, self.idle_time_limit, self.speed)
 
         except asciicast.LoadError as e:


### PR DESCRIPTION
Before playing a recorded file, check that the terminal that is running
the playback is at least as large as the recorded content.  This will
allow all the escape characters that change the location on the screen
to go to a legal spot and, therefore, everything should display
properly.

I've chosen to warn for a smaller size instead of causing an error in
case the playback doesn't use escape codes that are too large, but one
could argue that an error is legitimate here, too.