### PR TITLE
Make it possible to read the user var from the config

### DIFF
--- a/asciinema/commands/command.py
+++ b/asciinema/commands/command.py
@@ -7,7 +7,7 @@ class Command:
 
     def __init__(self, args, config, env):
         self.quiet = False
-        self.api = Api(config.api_url, env.get("USER"), config.install_id)
+        self.api = Api(config.api_url, config.user, config.install_id)
 
     def print(self, text, file=sys.stdout, end="\n", force=False):
         if not self.quiet or force:

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -85,6 +85,10 @@ class Config:
         )
 
     @property
+    def user(self):
+        return self.config.get('api', 'user', fallback=self.env.get("USER"))
+
+    @property
     def record_stdin(self):
         return self.config.getboolean('record', 'stdin', fallback=False)
 


### PR DESCRIPTION
Fixes #362 

This small change make it possible to set the user part for the basic auth in the upload process without affecting the USER env var.

- On my laptop the USER env var contains a full email address which made it impossible to upload any records due to an exception in the basic auth. Similar to #364 
- I also wanted to upload some recordings to my main account which was set from a different laptop and I don't want to change/set the USER var for this.