### PR TITLE
Consume terminal answerbacks in asciinema cat

### DIFF
--- a/asciinema/commands/cat.py
+++ b/asciinema/commands/cat.py
@@ -1,6 +1,7 @@
 import sys
 
 from asciinema.commands.command import Command
+from asciinema.term import raw
 import asciinema.asciicast as asciicast
 
 
@@ -12,10 +13,12 @@ class CatCommand(Command):
 
     def execute(self):
         try:
-            with asciicast.open_from_url(self.filename) as a:
-                for t, _type, text in a.stdout_events():
-                    sys.stdout.write(text)
-                    sys.stdout.flush()
+            stdin = open('/dev/tty')
+            with raw(stdin.fileno()):
+                with asciicast.open_from_url(self.filename) as a:
+                    for t, _type, text in a.stdout_events():
+                        sys.stdout.write(text)
+                        sys.stdout.flush()
 
         except asciicast.LoadError as e:
             self.print_error("printing failed: %s" % str(e))

--- a/asciinema/term.py
+++ b/asciinema/term.py
@@ -1,6 +1,7 @@
 import os
 import select
 import subprocess
+import time
 import tty
 
 
@@ -19,6 +20,8 @@ class raw():
 
     def __exit__(self, type, value, traceback):
         if self.restore:
+            # Give the terminal time to send answerbacks
+            time.sleep(0.05)
             tty.tcsetattr(self.fd, tty.TCSAFLUSH, self.mode)
 
 


### PR DESCRIPTION
If the asciicast contains escape sequence queries like "CSI 6 n", the terminal will both echo and input its responses.  Use the raw() context manager that we already have to attempt to consume this "input."

There is, unfortunately, no way of finding out exactly when the terminal has finished its answerbacks.  This patch adds a 50ms wait, which should be overkill for a local terminal (in my tests, 3ms was usually enough).  For a remote terminal, this number becomes harder to estimate.

Technically this only needs to be done if whatever we're writing to isatty(), but keep it simple for now.