### PR TITLE
Bugfix: Ensure ASCIINEMA_REC set on record (#372).

### DIFF
--- a/asciinema/recorder.py
+++ b/asciinema/recorder.py
@@ -15,7 +15,7 @@ def record(path, command=None, append=False, idle_time_limit=None,
 
     if command_env is None:
         command_env = os.environ.copy()
-        command_env['ASCIINEMA_REC'] = '1'
+    command_env['ASCIINEMA_REC'] = '1'
 
     if capture_env is None:
         capture_env = ['SHELL', 'TERM']


### PR DESCRIPTION
A simple fix to the ASCIINEMA_REC issue: [ASCIINEMA_REC is not set (#372)](https://github.com/asciinema/asciinema/issues/372).

To reproduce:

    $ asciinema rec -c 'echo "ASCIINEMA_REC=$ASCIINEMA_REC"'
    ASCIINEMA_REC=

Expected behavior:

    $ asciinema rec -c 'echo "ASCIINEMA_REC=$ASCIINEMA_REC"'
    ASCIINEMA_REC=1

Thanks for all your hard work!