### PR TITLE
Add "--show-timer" play option

### DIFF
--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -82,6 +82,7 @@ For help on a specific command run:
     parser_play = subparsers.add_parser('play', help='Replay terminal session')
     parser_play.add_argument('-i', '--idle-time-limit', help='limit idle time during playback to given number of seconds', type=positive_float, default=maybe_str(cfg.play_idle_time_limit))
     parser_play.add_argument('-s', '--speed', help='playback speedup (can be fractional)', type=positive_float, default=cfg.play_speed)
+    parser_play.add_argument('--show-timer', help='show time of each frame in top-right corner', action='store_true', default=cfg.play_show_timer)
     parser_play.add_argument('filename', help='local path, http/ipfs URL or "-" (read from stdin)')
     parser_play.set_defaults(cmd=PlayCommand)
 

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -10,12 +10,13 @@ class PlayCommand(Command):
         self.filename = args.filename
         self.idle_time_limit = args.idle_time_limit
         self.speed = args.speed
+        self.show_timer = args.show_timer
         self.player = player if player is not None else Player()
 
     def execute(self):
         try:
             with asciicast.open_from_url(self.filename) as a:
-                self.player.play(a, self.idle_time_limit, self.speed)
+                self.player.play(a, self.idle_time_limit, self.speed, self.show_timer)
 
         except asciicast.LoadError as e:
             self.print_error("playback failed: %s" % str(e))

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -119,6 +119,10 @@ class Config:
         return self.config.getfloat('play', 'speed', fallback=1.0)
 
     @property
+    def play_show_timer(self):
+        return self.config.getboolean('play', 'show_timer', fallback=False)
+
+    @property
     def notifications_enabled(self):
         return self.config.getboolean('notifications', 'enabled', fallback=True)
 


### PR DESCRIPTION
This option will show the current frame timer in a corner of the display.

This option can be useful when a user wants to edit a cast file:
- user plays the file with --show-timer and jots down interesting timestamps
- user knows where to insert/remove what they want in the cast file