### PR TITLE
Configurable key bindings (hotkeys) for rec and play commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,14 @@ speed = 2
 ; Limit replayed terminal inactivity to max n seconds, default: off
 idle_time_limit = 1
 
+; Define hotkey for pausing/resuming playback,
+; default: space
+pause_key = p
+
+; Define hotkey for stepping through playback, a frame at a time,
+; default: .
+pause_key = ]
+
 [notifications]
 
 ; Should desktop notifications be enabled, default: yes

--- a/README.md
+++ b/README.md
@@ -329,6 +329,14 @@ yes = true
 ; Be quiet, suppress all notices/warnings, default: no
 quiet = true
 
+; Define hotkey for pausing recording (suspending capture of output),
+; default: C-\
+pause_key = C-p
+
+; Define hotkey prefix key - when defined other recording hotkeys must
+; be preceeded by it, default: no prefix
+prefix_key = C-a
+
 [play]
 
 ; Playback speed (can be fractional), default: 1

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -11,11 +11,15 @@ class PlayCommand(Command):
         self.idle_time_limit = args.idle_time_limit
         self.speed = args.speed
         self.player = player if player is not None else Player()
+        self.key_bindings = {
+            'pause': config.play_pause_key,
+            'step': config.play_step_key
+        }
 
     def execute(self):
         try:
             with asciicast.open_from_url(self.filename) as a:
-                self.player.play(a, self.idle_time_limit, self.speed)
+                self.player.play(a, self.idle_time_limit, self.speed, self.key_bindings)
 
         except asciicast.LoadError as e:
             self.print_error("playback failed: %s" % str(e))

--- a/asciinema/commands/record.py
+++ b/asciinema/commands/record.py
@@ -28,6 +28,10 @@ class RecordCommand(Command):
         self.writer = raw.writer if args.raw else v2.writer
         self.notifier = notifier.get_notifier(config.notifications_enabled, config.notifications_command)
         self.env = env
+        self.key_bindings = {
+            'prefix': config.record_prefix_key,
+            'pause': config.record_pause_key
+        }
 
     def execute(self):
         upload = False
@@ -78,7 +82,8 @@ class RecordCommand(Command):
                 capture_env=vars,
                 rec_stdin=self.rec_stdin,
                 writer=self.writer,
-                notifier=self.notifier
+                notifier=self.notifier,
+                key_bindings=self.key_bindings
             )
         except v2.LoadError:
             self.print_error("can only append to asciicast v2 format recordings")

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -110,6 +110,14 @@ class Config:
         return self.config.getboolean('record', 'quiet', fallback=False)
 
     @property
+    def record_prefix_key(self):
+        return self.__get_key('record', 'prefix')
+
+    @property
+    def record_pause_key(self):
+        return self.__get_key('record', 'pause', 'C-\\')
+
+    @property
     def play_idle_time_limit(self):
         fallback = self.config.getfloat('play', 'maxwait', fallback=None)  # pre 2.0
         return self.config.getfloat('play', 'idle_time_limit', fallback=fallback)
@@ -125,6 +133,20 @@ class Config:
     @property
     def notifications_command(self):
         return self.config.get('notifications', 'command', fallback=None)
+
+    def __get_key(self, section, name, default=None):
+        key = self.config.get(section, f'{name}_key', fallback=default)
+
+        if key:
+            if len(key) == 3:
+                upper_key = key.upper()
+
+                if upper_key[0] == 'C' and upper_key[1] == '-':
+                    return bytes([ord(upper_key[2]) - 0x40])
+                else:
+                    raise ConfigError(f'invalid {name} key definition \'{key}\' - use: {name}_key = C-x (with control key modifier), or {name}_key = x (with no modifier)')
+            else:
+                return key.encode('utf-8')
 
 
 def get_config_home(env=os.environ):

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -127,6 +127,14 @@ class Config:
         return self.config.getfloat('play', 'speed', fallback=1.0)
 
     @property
+    def play_pause_key(self):
+        return self.__get_key('play', 'pause', ' ')
+
+    @property
+    def play_step_key(self):
+        return self.__get_key('play', 'step', '.')
+
+    @property
     def notifications_enabled(self):
         return self.config.getboolean('notifications', 'enabled', fallback=True)
 

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -143,7 +143,7 @@ class Config:
         return self.config.get('notifications', 'command', fallback=None)
 
     def __get_key(self, section, name, default=None):
-        key = self.config.get(section, f'{name}_key', fallback=default)
+        key = self.config.get(section, name + '_key', fallback=default)
 
         if key:
             if len(key) == 3:
@@ -152,7 +152,7 @@ class Config:
                 if upper_key[0] == 'C' and upper_key[1] == '-':
                     return bytes([ord(upper_key[2]) - 0x40])
                 else:
-                    raise ConfigError(f'invalid {name} key definition \'{key}\' - use: {name}_key = C-x (with control key modifier), or {name}_key = x (with no modifier)')
+                    raise ConfigError('invalid {name} key definition \'{key}\' - use: {name}_key = C-x (with control key modifier), or {name}_key = x (with no modifier)'.format(name=name, key=key))
             else:
                 return key.encode('utf-8')
 

--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -8,16 +8,18 @@ from asciinema.term import raw, read_blocking
 
 class Player:
 
-    def play(self, asciicast, idle_time_limit=None, speed=1.0):
+    def play(self, asciicast, idle_time_limit=None, speed=1.0, key_bindings={}):
         try:
             stdin = open('/dev/tty')
             with raw(stdin.fileno()):
-                self._play(asciicast, idle_time_limit, speed, stdin)
+                self._play(asciicast, idle_time_limit, speed, stdin, key_bindings)
         except Exception:
-            self._play(asciicast, idle_time_limit, speed, None)
+            self._play(asciicast, idle_time_limit, speed, None, key_bindings)
 
-    def _play(self, asciicast, idle_time_limit, speed, stdin):
+    def _play(self, asciicast, idle_time_limit, speed, stdin, key_bindings):
         idle_time_limit = idle_time_limit or asciicast.idle_time_limit
+        pause_key = key_bindings.get('pause')
+        step_key = key_bindings.get('step')
 
         stdout = asciicast.stdout_events()
         stdout = ev.to_relative_time(stdout)
@@ -42,12 +44,12 @@ class Player:
                             ctrl_c = True
                             break
 
-                        if 0x20 in data:  # space
+                        if data == pause_key:
                             paused = False
                             base_time = base_time + (time.time() - pause_time)
                             break
 
-                        if 0x2e in data:  # period (dot)
+                        if data == step_key:
                             delay = 0
                             pause_time = time.time()
                             base_time = pause_time - t
@@ -62,7 +64,7 @@ class Player:
                         ctrl_c = True
                         break
 
-                    if 0x20 in data:  # space
+                    if data == pause_key:
                         paused = True
                         pause_time = time.time()
                         slept = t - (pause_time - base_time)

--- a/asciinema/recorder.py
+++ b/asciinema/recorder.py
@@ -9,7 +9,8 @@ from asciinema.async_worker import async_worker
 
 def record(path, command=None, append=False, idle_time_limit=None,
            rec_stdin=False, title=None, metadata=None, command_env=None,
-           capture_env=None, writer=v2.writer, record=pty.record, notifier=None):
+           capture_env=None, writer=v2.writer, record=pty.record, notifier=None,
+           key_bindings={}):
     if command is None:
         command = os.environ.get('SHELL') or 'sh'
 
@@ -53,7 +54,8 @@ def record(path, command=None, append=False, idle_time_limit=None,
                 command_env,
                 rec_stdin,
                 time_offset,
-                n
+                n,
+                key_bindings
             )
 
 


### PR DESCRIPTION
Fixes #343.

This implements configurable hotkeys for `rec` and `play` commands.

Example config file:

```ini
[record]

; Define hotkey for pausing recording (suspending capture of output),
; default: C-\
pause_key = C-p

; Define hotkey prefix key - when defined other recording hotkeys must
; be preceeded by it, default: no prefix
prefix_key = C-a

[play]

; Define hotkey for pausing/resuming playback,
; default: space
pause_key = p

; Define hotkey for stepping through playback, a frame at a time,
; default: . (dot key)
step_key = ]
```
