### PR TITLE
Use os.get_terminal_size()

### DIFF
--- a/asciinema/term.py
+++ b/asciinema/term.py
@@ -33,8 +33,10 @@ def read_blocking(fd, timeout):
 
 
 def get_size():
-    # TODO maybe use os.get_terminal_size ?
-    return (
-        int(subprocess.check_output(['tput', 'cols'])),
-        int(subprocess.check_output(['tput', 'lines']))
-    )
+    try:
+        return os.get_terminal_size()
+    except:
+        return (
+            int(subprocess.check_output(['tput', 'cols'])),
+            int(subprocess.check_output(['tput', 'lines']))
+        )


### PR DESCRIPTION
tput is part of ncurses, which may not be installed.

It still falls back to tput for older Python versions (this was
introduced in 3.3) or for platforms which may not support it.

Fixes #418