### PR TITLE
setup.cfg: fix deprecated key usage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 license_file = LICENSE
 
 [pycodestyle]


### PR DESCRIPTION
This solves the warning:
```
/usr/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead