### PR TITLE
Feature: implement --begin-at flag for play command (fix #447)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Available options:
 
 * `-i, --idle-time-limit=<sec>` - Limit replayed terminal inactivity to max `<sec>` seconds
 * `-s, --speed=<factor>` - Playback speed (can be fractional)
+* `-b, --begin-at=<ts>` - Begin at relative time when playing (can be fractional)
 
 > For the best playback experience it is recommended to run `asciinema play` in
 > a terminal of dimensions not smaller than the one used for recording, as

--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -82,6 +82,7 @@ For help on a specific command run:
     parser_play = subparsers.add_parser('play', help='Replay terminal session')
     parser_play.add_argument('-i', '--idle-time-limit', help='limit idle time during playback to given number of seconds', type=positive_float, default=maybe_str(cfg.play_idle_time_limit))
     parser_play.add_argument('-s', '--speed', help='playback speedup (can be fractional)', type=positive_float, default=cfg.play_speed)
+    parser_play.add_argument('-b', '--begin-at', help='begin at relative time when playing', type=positive_float, default=0)
     parser_play.add_argument('filename', help='local path, http/ipfs URL or "-" (read from stdin)')
     parser_play.set_defaults(cmd=PlayCommand)
 

--- a/asciinema/asciicast/events.py
+++ b/asciinema/asciicast/events.py
@@ -26,3 +26,10 @@ def cap_relative_time(events, time_limit):
 
 def adjust_speed(events, speed):
     return ([delay / speed, type, data] for delay, type, data in events)
+
+
+def begin_at(events, begin_at_time=0):
+    for frame in events:
+        time, type, data = frame
+        if time >= begin_at_time:
+            yield [time - begin_at_time, type, data]

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -10,6 +10,7 @@ class PlayCommand(Command):
         self.filename = args.filename
         self.idle_time_limit = args.idle_time_limit
         self.speed = args.speed
+        self.begin_at = args.begin_at
         self.player = player if player is not None else Player()
         self.key_bindings = {
             'pause': config.play_pause_key,
@@ -19,7 +20,7 @@ class PlayCommand(Command):
     def execute(self):
         try:
             with asciicast.open_from_url(self.filename) as a:
-                self.player.play(a, self.idle_time_limit, self.speed, self.key_bindings)
+                self.player.play(a, self.idle_time_limit, self.speed, self.begin_at, self.key_bindings)
 
         except asciicast.LoadError as e:
             self.print_error("playback failed: %s" % str(e))

--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -8,20 +8,21 @@ from asciinema.term import raw, read_blocking
 
 class Player:
 
-    def play(self, asciicast, idle_time_limit=None, speed=1.0, key_bindings={}):
+    def play(self, asciicast, idle_time_limit=None, speed=1.0, begin_at=0, key_bindings={}):
         try:
             stdin = open('/dev/tty')
             with raw(stdin.fileno()):
-                self._play(asciicast, idle_time_limit, speed, stdin, key_bindings)
+                self._play(asciicast, idle_time_limit, speed, begin_at, stdin, key_bindings)
         except Exception:
-            self._play(asciicast, idle_time_limit, speed, None, key_bindings)
+            self._play(asciicast, idle_time_limit, speed, begin_at, None, key_bindings)
 
-    def _play(self, asciicast, idle_time_limit, speed, stdin, key_bindings):
+    def _play(self, asciicast, idle_time_limit, speed, begin_at, stdin, key_bindings):
         idle_time_limit = idle_time_limit or asciicast.idle_time_limit
         pause_key = key_bindings.get('pause')
         step_key = key_bindings.get('step')
 
         stdout = asciicast.stdout_events()
+        stdout = ev.begin_at(stdout, begin_at)
         stdout = ev.to_relative_time(stdout)
         stdout = ev.cap_relative_time(stdout, idle_time_limit)
         stdout = ev.to_absolute_time(stdout)


### PR DESCRIPTION
Add one new cli flag `--begin-at` for play command. This option accepts
one fractional as relative time and will skip till this time when playing. 