### PR TITLE
djds/annotate

### DIFF
--- a/.github/workflows/asciinema.yml
+++ b/.github/workflows/asciinema.yml
@@ -1,22 +1,21 @@
+---
 name: build
-
 on:
   - push
   - pull_request
-
 jobs:
   # Code style checks
   health:
-    name: Code health check
+    name: code health check
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Asciinema
+      - name: checkout asciinema
         uses: actions/checkout@v2
-      - name: Setup Python
+      - name: setup Python
         uses: actions/setup-python@v2
         with:
           python-version: "3.9"
-      - name: Install dependencies
+      - name: install dependencies
         run: pip install build cmarkgfm pycodestyle twine
       - name: Run pycodestyle
         run: >
@@ -27,7 +26,7 @@ jobs:
           twine check dist/*
   # Asciinema checks
   asciinema:
-    name: Asciinema - py${{ matrix.python }}
+    name: Asciinema
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,13 +39,70 @@ jobs:
     env:
       TERM: dumb
     steps:
-      - name: Checkout Asciinema
+      - name: checkout Asciinema
         uses: actions/checkout@v2
-      - name: Setup Python
+      - name: setup Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: Install dependencies
+      - name: install dependencies
         run: pip install pytest
-      - name: Run Asciinema tests
+      - name: run Asciinema tests
         run: script -e -c make test
+  build_distros:
+    name: build distro images
+    strategy:
+      matrix:
+        distros:
+          - alpine
+          - arch
+          - centos
+          - debian
+          - fedora
+          - ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Authenticate to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+      - name: "Build ${{ matrix.distros }} image"
+        uses: docker/build-push-action@v2
+        with:
+          file: "tests/distros/Dockerfile.${{ matrix.distros }}"
+          tags: |
+            "ghcr.io/${{ github.repository }}:${{ matrix.distros }}"
+          push: true
+  test_distros:
+    name: integration test distro images
+    needs: build_distros
+    strategy:
+      matrix:
+        distros:
+          - alpine
+          - arch
+          - centos
+          - debian
+          - fedora
+          - ubuntu
+    runs-on: ubuntu-latest
+    container:
+      image: "ghcr.io/${{ github.repository }}:${{ matrix.distros }}"
+      credentials:
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
+      # https://github.community/t/permission-problems-when-checking-out-code-as-part-of-github-action/202263
+      options: "--interactive --tty --user=1001:121"  
+    steps:
+      - name: checkout Asciinema
+        uses: actions/checkout@v2
+      - name: run integration tests
+        env:
+          TERM: dumb
+        shell: 'script --return --quiet --command "bash {0}"'
+        run: make test.integration

--- a/.github/workflows/asciinema.yml
+++ b/.github/workflows/asciinema.yml
@@ -19,7 +19,9 @@ jobs:
         run: pip install build cmarkgfm pycodestyle twine
       - name: Run pycodestyle
         run: >
-          find . -name '*\.py' -exec pycodestyle --ignore=E501,E402,E722 "{}" \+
+          find .
+          -name '*\.py'
+          -exec pycodestyle --ignore=E402,E501,E722,W503 "{}" \+
       - name: Run twine
         run: |
           python3 -m build
@@ -97,7 +99,7 @@ jobs:
         username: "${{ github.actor }}"
         password: "${{ secrets.GITHUB_TOKEN }}"
       # https://github.community/t/permission-problems-when-checking-out-code-as-part-of-github-action/202263
-      options: "--interactive --tty --user=1001:121"  
+      options: "--interactive --tty --user=1001:121"
     steps:
       - name: checkout Asciinema
         uses: actions/checkout@v2

--- a/.github/workflows/asciinema.yml
+++ b/.github/workflows/asciinema.yml
@@ -1,6 +1,8 @@
 name: build
 
-on: [push, pull_request]
+on:
+  - push
+  - pull_request
 
 jobs:
   # Code style checks
@@ -13,14 +15,15 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.9"
       - name: Install dependencies
-        run: pip install pycodestyle twine setuptools>=38.6.0 cmarkgfm
+        run: pip install build cmarkgfm pycodestyle twine
       - name: Run pycodestyle
-        run: find . -name \*.py -exec pycodestyle --ignore=E501,E402,E722 {} +
+        run: >
+          find . -name '*\.py' -exec pycodestyle --ignore=E501,E402,E722 "{}" \+
       - name: Run twine
         run: |
-          python setup.py --quiet sdist
+          python3 -m build
           twine check dist/*
   # Asciinema checks
   asciinema:
@@ -28,7 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
     env:
       TERM: dumb
     steps:
@@ -39,6 +47,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: pip install nose
+        run: pip install pytest
       - name: Run Asciinema tests
         run: script -e -c make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,27 +9,28 @@ RUN apt-get update \
         ca-certificates \
         locales \
         python3 \
-        python3-setuptools \
+        python3-pip \
     && localedef \
         -i en_US \
         -c \
         -f UTF-8 \
-        -A /usr/share/locale/locale.alias en_US.UTF-8
+        -A /usr/share/locale/locale.alias \
+        en_US.UTF-8
 
-COPY setup.cfg setup.py *.md /usr/src/app/
+COPY pyproject.toml setup.cfg *.md /usr/src/app/
 COPY doc/*.md /usr/src/app/doc/
 COPY man/asciinema.1 /usr/src/app/man/
 COPY asciinema/ /usr/src/app/asciinema/
+COPY README.md LICENSE /usr/src/app/
 
 WORKDIR /usr/src/app
 
-RUN python3 setup.py install
+RUN pip3 install .
+
+WORKDIR /root
 
 ENV LANG="en_US.utf8"
 ENV SHELL="/bin/bash"
-ENV USER="docker"
-
-WORKDIR /root
 
 ENTRYPOINT ["/usr/local/bin/asciinema"]
 CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,10 @@ push: .pip build
 push.test: .pip build
 	python3 -m twine upload --repository testpypi dist/*
 
+
+.PHONY: clean
+clean:
+	rm -rf dist *.egg-info
+
+clean.all: clean
+	find . -type d -name __pycache__ -o -name .pytest_cache -exec rm -r "{}" +

--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,9 @@ clean:
 	rm -rf dist *.egg-info
 
 clean.all: clean
-	find . -type d -name __pycache__ -o -name .pytest_cache -exec rm -r "{}" +
+	find .  \
+		-type d \
+		-name __pycache__ \
+		-o -name .pytest_cache \
+		-o -name .mypy_cache \
+		-exec rm -r "{}" +

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 NAME    := asciinema
 VERSION := $(shell python3 -c "import asciinema; print(asciinema.__version__)")
 
+VIRTUAL_ENV ?= .venv
+
 .PHONY: test
 test: test.unit test.integration
 
@@ -30,13 +32,22 @@ tag: .tag.exists
 	git tag -s -m "Releasing $(VERSION)" v$(VERSION)
 	git push origin v$(VERSION)
 
+.PHONY: .venv
+.venv:
+	python3 -m venv $(VIRTUAL_ENV)
 
 .PHONY: .pip
-.pip:
-	python3 -m pip install --user --upgrade --quiet build twine
+.pip: .venv
+	. $(VIRTUAL_ENV)/bin/activate \
+		&& python3 -m pip install --upgrade build twine
 
-build:
-	python3 -m build .
+build: .pip
+	. $(VIRTUAL_ENV)/bin/activate \
+		&& python3 -m build .
+
+install: build
+	. $(VIRTUAL_ENV)/bin/activate \
+		&& python3 -m pip install .
 
 .PHONY: push
 push: .pip build

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test: test.unit test.integration
 
 .PHONY: test.unit
 test.unit:
-	nosetests
+	pytest
 
 .PHONY: test.integration
 test.integration:

--- a/README.md
+++ b/README.md
@@ -18,19 +18,27 @@ them in a terminal as well as in a web browser.
 
 Install latest version ([other installation options](#installation)):
 
-    sudo pip3 install asciinema
+```sh
+pip3 install asciinema
+```
 
 Record your first session:
 
-    asciinema rec first.cast
+```sh
+asciinema rec first.cast
+```
 
 Now replay it with double speed:
 
-    asciinema play -s 2 first.cast
+```sh
+asciinema play -s 2 first.cast
+```
 
 Or with normal speed but with idle time limited to 2 seconds:
 
-    asciinema play -i 2 first.cast
+```sh
+asciinema play -i 2 first.cast
+```
 
 You can pass `-i 2` to `asciinema rec` as well, to set it permanently on a
 recording. Idle time limiting makes the recordings much more interesting to
@@ -38,7 +46,9 @@ watch. Try it.
 
 If you want to watch and share it on the web, upload it:
 
-    asciinema upload first.cast
+```sh
+asciinema upload first.cast
+```
 
 The above uploads it to [asciinema.org](https://asciinema.org), which is a
 default [asciinema-server](https://github.com/asciinema/asciinema-server)
@@ -47,13 +57,16 @@ browser.
 
 You can record and upload in one step by omitting the filename:
 
-    asciinema rec
+```sh
+asciinema rec
+```
 
 You'll be asked to confirm the upload when the recording is done. Nothing is
 sent anywhere without your consent.
 
 These are the basics, but there's much more you can do. The following sections
 cover installation, usage and hosting of the recordings in more detail.
+
 
 ## Installation
 
@@ -62,7 +75,9 @@ cover installation, usage and hosting of the recordings in more detail.
 asciinema is available on [PyPI](https://pypi.python.org/pypi/asciinema) and can
 be installed with pip (Python 3 with setuptools required):
 
-    sudo pip3 install asciinema
+```sh
+pip3 install asciinema
+```
 
 This is the recommended way of installation, which gives you the latest released
 version.
@@ -80,32 +95,45 @@ can clone the repo and run asciinema straight from the checkout.
 
 Clone the repo:
 
-    git clone https://github.com/asciinema/asciinema.git
-    cd asciinema
+```sh
+git clone https://github.com/asciinema/asciinema.git
+cd asciinema
+```
 
 If you want latest stable version:
 
-    git checkout master
+```sh
+git checkout master
+```
 
 If you want current development version:
 
-    git checkout develop
+```sh
+git checkout develop
+```
 
 Then run it with:
 
-    python3 -m asciinema --version
+```sh
+python3 -m asciinema --version
+```
 
 ### Docker image
 
-asciinema Docker image is based on Ubuntu 18.04 and has the latest version of
+asciinema Docker image is based on [Ubuntu
+20.04](https://releases.ubuntu.com/20.04/) and has the latest version of
 asciinema recorder pre-installed.
 
-    docker pull asciinema/asciinema
+```sh
+docker pull docker.io/asciinema/asciinema
+```
 
 When running it don't forget to allocate a pseudo-TTY (`-t`), keep STDIN open
 (`-i`) and mount config directory volume (`-v`):
 
-    docker run --rm -ti -v "$HOME/.config/asciinema":/root/.config/asciinema asciinema/asciinema rec
+```sh
+docker run --rm -it -v "${HOME}/.config/asciinema:/root/.config/asciinema" docker.io/asciinema/asciinema rec
+```
 
 Container's entrypoint is set to `/usr/local/bin/asciinema` so you can run the
 container with any arguments you would normally pass to `asciinema` binary (see
@@ -117,9 +145,26 @@ image from this one (start your custom Dockerfile with `FROM
 asciinema/asciinema`). Another option is to start the container with `/bin/bash`
 as the entrypoint, install extra packages and manually start `asciinema rec`:
 
-    docker run --rm -ti -v "$HOME/.config/asciinema":/root/.config/asciinema --entrypoint=/bin/bash asciinema/asciinema
-    root@6689517d99a1:~# apt-get install foobar
-    root@6689517d99a1:~# asciinema rec
+```console
+docker run --rm -it -v "${HOME}/.config/asciinema:/root/.config/asciinema" --entrypoint=/bin/bash docker.io/asciinema/asciinema rec
+root@6689517d99a1:~# apt-get install foobar
+root@6689517d99a1:~# asciinema rec
+```
+
+It is also possible to run the docker container as a non-root user, which has
+security benefits. You can specify a user and group id at runtime to give the
+application permission similar to the calling user on your host.
+
+```sh
+docker run --rm -it \
+    --env=ASCIINEMA_CONFIG_HOME="/run/user/$(id -u)/.config/asciinema" \
+    --user="$(id -u):$(id -g)" \
+    --volume="${HOME}/.config/asciinema:/run/user/$(id -u)/.config/asciinema:rw" \
+    --volume="${PWD}:/data:rw" \
+    --workdir='/data' \
+    docker.io/asciinema/asciinema rec
+```
+
 
 ## Usage
 
@@ -196,27 +241,37 @@ Following keyboard shortcuts are available:
 
 Playing from a local file:
 
-    asciinema play /path/to/asciicast.cast
+```sh
+asciinema play /path/to/asciicast.cast
+```
 
 Playing from HTTP(S) URL:
 
-    asciinema play https://asciinema.org/a/22124.cast
-    asciinema play http://example.com/demo.cast
+```sh
+asciinema play https://asciinema.org/a/22124.cast
+asciinema play http://example.com/demo.cast
+```
 
 Playing from asciicast page URL (requires `<link rel="alternate"
 type="application/x-asciicast" href="/my/ascii.cast">` in page's HTML):
 
-    asciinema play https://asciinema.org/a/22124
-    asciinema play http://example.com/blog/post.html
+```sh
+asciinema play https://asciinema.org/a/22124
+asciinema play http://example.com/blog/post.html
+```
 
 Playing from stdin:
 
-    cat /path/to/asciicast.cast | asciinema play -
-    ssh user@host cat asciicast.cast | asciinema play -
+```sh
+cat /path/to/asciicast.cast | asciinema play -
+ssh user@host cat asciicast.cast | asciinema play -
+```
 
 Playing from IPFS:
 
-    asciinema play dweb:/ipfs/QmNe7FsYaHc9SaDEAEXbaagAzNw9cH7YbzN4xV7jV1MCzK/ascii.cast
+```sh
+asciinema play dweb:/ipfs/QmNe7FsYaHc9SaDEAEXbaagAzNw9cH7YbzN4xV7jV1MCzK/ascii.cast
+```
 
 Available options:
 
@@ -391,6 +446,7 @@ source [contributors](https://github.com/asciinema/asciinema/contributors).
 
 ## License
 
-Copyright &copy; 2011–2019 Marcin Kulik.
+Copyright &copy; 2011–2021 Marcin Kulik.
 
-All code is licensed under the GPL, v3 or later. See LICENSE file for details.
+All code is licensed under the GPL, v3 or later. See [LICENSE](./LICENSE) file
+for details.

--- a/asciinema/__init__.py
+++ b/asciinema/__init__.py
@@ -7,18 +7,18 @@ if sys.version_info < (3, 7):
     raise ImportError("Python < 3.7 is unsupported.")
 
 # pylint: disable=wrong-import-position
-from typing import Any
+from typing import Any, Optional
 
 from .recorder import record
 
 
-def record_asciicast(
-    path_,
-    command=None,
-    append=False,
-    idle_time_limit=None,
-    rec_stdin=False,
-    title=None,
+def record_asciicast(  # pylint: disable=too-many-arguments
+    path_: str,
+    command: Any = None,
+    append: bool = False,
+    idle_time_limit: Optional[int] = None,
+    rec_stdin: bool = False,
+    title: Optional[str] = None,
     metadata: Any = None,
     command_env: Any = None,
     capture_env: Any = None,

--- a/asciinema/__init__.py
+++ b/asciinema/__init__.py
@@ -3,8 +3,8 @@ import sys
 __author__ = "Marcin Kulik"
 __version__ = "2.0.2"
 
-if sys.version_info < (3, 7):
-    raise ImportError("Python < 3.7 is unsupported.")
+if sys.version_info < (3, 6):
+    raise ImportError("Python < 3.6 is unsupported.")
 
 # pylint: disable=wrong-import-position
 from typing import Any, Optional

--- a/asciinema/__init__.py
+++ b/asciinema/__init__.py
@@ -1,7 +1,7 @@
 import sys
 
 __author__ = "Marcin Kulik"
-__version__ = "2.0.2"
+__version__ = "2.2.0"
 
 if sys.version_info < (3, 6):
     raise ImportError("Python < 3.6 is unsupported.")

--- a/asciinema/__init__.py
+++ b/asciinema/__init__.py
@@ -1,19 +1,30 @@
 import sys
 
-__author__ = 'Marcin Kulik'
-__version__ = '2.0.2'
+__author__ = "Marcin Kulik"
+__version__ = "2.0.2"
 
-if sys.version_info[0] < 3:
-    raise ImportError('Python < 3 is unsupported.')
+if sys.version_info < (3, 7):
+    raise ImportError("Python < 3.7 is unsupported.")
 
-import asciinema.recorder
+# pylint: disable=wrong-import-position
+from typing import Any
+
+from .recorder import record
 
 
-def record_asciicast(path, command=None, append=False, idle_time_limit=None,
-                     rec_stdin=False, title=None, metadata=None,
-                     command_env=None, capture_env=None):
-    asciinema.recorder.record(
-        path,
+def record_asciicast(
+    path_,
+    command=None,
+    append=False,
+    idle_time_limit=None,
+    rec_stdin=False,
+    title=None,
+    metadata: Any = None,
+    command_env: Any = None,
+    capture_env: Any = None,
+) -> None:
+    record(
+        path_,
         command=command,
         append=append,
         idle_time_limit=idle_time_limit,
@@ -21,5 +32,5 @@ def record_asciicast(path, command=None, append=False, idle_time_limit=None,
         title=title,
         metadata=metadata,
         command_env=command_env,
-        capture_env=capture_env
+        capture_env=capture_env,
     )

--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -1,14 +1,14 @@
-import locale
 import argparse
+import locale
 import os
 import sys
 
-from asciinema import __version__
 import asciinema.config as config
+from asciinema import __version__
 from asciinema.commands.auth import AuthCommand
-from asciinema.commands.record import RecordCommand
-from asciinema.commands.play import PlayCommand
 from asciinema.commands.cat import CatCommand
+from asciinema.commands.play import PlayCommand
+from asciinema.commands.record import RecordCommand
 from asciinema.commands.upload import UploadCommand
 
 
@@ -26,14 +26,20 @@ def maybe_str(v):
 
 
 def main():
-    if locale.nl_langinfo(locale.CODESET).upper() not in ['US-ASCII', 'UTF-8', 'UTF8']:
-        print("asciinema needs an ASCII or UTF-8 character encoding to run. Check the output of `locale` command.")
+    if locale.nl_langinfo(locale.CODESET).upper() not in [
+        "US-ASCII",
+        "UTF-8",
+        "UTF8",
+    ]:
+        print(
+            "asciinema needs an ASCII or UTF-8 character encoding to run. Check the output of `locale` command."
+        )
         sys.exit(1)
 
     try:
         cfg = config.load()
     except config.ConfigError as e:
-        sys.stderr.write(str(e) + '\n')
+        sys.stderr.write(str(e) + "\n")
         sys.exit(1)
 
     # create the top-level parser
@@ -57,52 +63,132 @@ def main():
 
 For help on a specific command run:
   \x1b[1masciinema <command> -h\x1b[0m""",
-        formatter_class=argparse.RawDescriptionHelpFormatter
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument('--version', action='version', version='asciinema %s' % __version__)
+    parser.add_argument(
+        "--version", action="version", version="asciinema %s" % __version__
+    )
 
     subparsers = parser.add_subparsers()
 
     # create the parser for the "rec" command
-    parser_rec = subparsers.add_parser('rec', help='Record terminal session')
-    parser_rec.add_argument('--stdin', help='enable stdin recording, disabled by default', action='store_true', default=cfg.record_stdin)
-    parser_rec.add_argument('--append', help='append to existing recording', action='store_true', default=False)
-    parser_rec.add_argument('--raw', help='save only raw stdout output', action='store_true', default=False)
-    parser_rec.add_argument('--overwrite', help='overwrite the file if it already exists', action='store_true', default=False)
-    parser_rec.add_argument('-c', '--command', help='command to record, defaults to $SHELL', default=cfg.record_command)
-    parser_rec.add_argument('-e', '--env', help='list of environment variables to capture, defaults to ' + config.DEFAULT_RECORD_ENV, default=cfg.record_env)
-    parser_rec.add_argument('-t', '--title', help='title of the asciicast')
-    parser_rec.add_argument('-i', '--idle-time-limit', help='limit recorded idle time to given number of seconds', type=positive_float, default=maybe_str(cfg.record_idle_time_limit))
-    parser_rec.add_argument('-y', '--yes', help='answer "yes" to all prompts (e.g. upload confirmation)', action='store_true', default=cfg.record_yes)
-    parser_rec.add_argument('-q', '--quiet', help='be quiet, suppress all notices/warnings (implies -y)', action='store_true', default=cfg.record_quiet)
-    parser_rec.add_argument('filename', nargs='?', default='', help='filename/path to save the recording to')
+    parser_rec = subparsers.add_parser("rec", help="Record terminal session")
+    parser_rec.add_argument(
+        "--stdin",
+        help="enable stdin recording, disabled by default",
+        action="store_true",
+        default=cfg.record_stdin,
+    )
+    parser_rec.add_argument(
+        "--append",
+        help="append to existing recording",
+        action="store_true",
+        default=False,
+    )
+    parser_rec.add_argument(
+        "--raw",
+        help="save only raw stdout output",
+        action="store_true",
+        default=False,
+    )
+    parser_rec.add_argument(
+        "--overwrite",
+        help="overwrite the file if it already exists",
+        action="store_true",
+        default=False,
+    )
+    parser_rec.add_argument(
+        "-c",
+        "--command",
+        help="command to record, defaults to $SHELL",
+        default=cfg.record_command,
+    )
+    parser_rec.add_argument(
+        "-e",
+        "--env",
+        help="list of environment variables to capture, defaults to "
+        + config.DEFAULT_RECORD_ENV,
+        default=cfg.record_env,
+    )
+    parser_rec.add_argument("-t", "--title", help="title of the asciicast")
+    parser_rec.add_argument(
+        "-i",
+        "--idle-time-limit",
+        help="limit recorded idle time to given number of seconds",
+        type=positive_float,
+        default=maybe_str(cfg.record_idle_time_limit),
+    )
+    parser_rec.add_argument(
+        "-y",
+        "--yes",
+        help='answer "yes" to all prompts (e.g. upload confirmation)',
+        action="store_true",
+        default=cfg.record_yes,
+    )
+    parser_rec.add_argument(
+        "-q",
+        "--quiet",
+        help="be quiet, suppress all notices/warnings (implies -y)",
+        action="store_true",
+        default=cfg.record_quiet,
+    )
+    parser_rec.add_argument(
+        "filename",
+        nargs="?",
+        default="",
+        help="filename/path to save the recording to",
+    )
     parser_rec.set_defaults(cmd=RecordCommand)
 
     # create the parser for the "play" command
-    parser_play = subparsers.add_parser('play', help='Replay terminal session')
-    parser_play.add_argument('-i', '--idle-time-limit', help='limit idle time during playback to given number of seconds', type=positive_float, default=maybe_str(cfg.play_idle_time_limit))
-    parser_play.add_argument('-s', '--speed', help='playback speedup (can be fractional)', type=positive_float, default=cfg.play_speed)
-    parser_play.add_argument('filename', help='local path, http/ipfs URL or "-" (read from stdin)')
+    parser_play = subparsers.add_parser("play", help="Replay terminal session")
+    parser_play.add_argument(
+        "-i",
+        "--idle-time-limit",
+        help="limit idle time during playback to given number of seconds",
+        type=positive_float,
+        default=maybe_str(cfg.play_idle_time_limit),
+    )
+    parser_play.add_argument(
+        "-s",
+        "--speed",
+        help="playback speedup (can be fractional)",
+        type=positive_float,
+        default=cfg.play_speed,
+    )
+    parser_play.add_argument(
+        "filename", help='local path, http/ipfs URL or "-" (read from stdin)'
+    )
     parser_play.set_defaults(cmd=PlayCommand)
 
     # create the parser for the "cat" command
-    parser_cat = subparsers.add_parser('cat', help='Print full output of terminal session')
-    parser_cat.add_argument('filename', help='local path, http/ipfs URL or "-" (read from stdin)')
+    parser_cat = subparsers.add_parser(
+        "cat", help="Print full output of terminal session"
+    )
+    parser_cat.add_argument(
+        "filename", help='local path, http/ipfs URL or "-" (read from stdin)'
+    )
     parser_cat.set_defaults(cmd=CatCommand)
 
     # create the parser for the "upload" command
-    parser_upload = subparsers.add_parser('upload', help='Upload locally saved terminal session to asciinema.org')
-    parser_upload.add_argument('filename', help='filename or path of local recording')
+    parser_upload = subparsers.add_parser(
+        "upload", help="Upload locally saved terminal session to asciinema.org"
+    )
+    parser_upload.add_argument(
+        "filename", help="filename or path of local recording"
+    )
     parser_upload.set_defaults(cmd=UploadCommand)
 
     # create the parser for the "auth" command
-    parser_auth = subparsers.add_parser('auth', help='Manage recordings on asciinema.org account')
+    parser_auth = subparsers.add_parser(
+        "auth", help="Manage recordings on asciinema.org account"
+    )
     parser_auth.set_defaults(cmd=AuthCommand)
 
     # parse the args and call whatever function was selected
     args = parser.parse_args()
 
-    if hasattr(args, 'cmd'):
+    if hasattr(args, "cmd"):
         command = args.cmd(args, cfg, os.environ)
         code = command.execute()
         sys.exit(code)
@@ -111,5 +197,5 @@ For help on a specific command run:
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -66,7 +66,7 @@ For help on a specific command run:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "--version", action="version", version="asciinema %s" % __version__
+        "--version", action="version", version=f"asciinema {__version__}"
     )
 
     subparsers = parser.add_subparsers()

--- a/asciinema/api.py
+++ b/asciinema/api.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import json
 import platform
 import re
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 from urllib.parse import urlparse
 
-from asciinema import __version__
-from asciinema.http_adapter import HTTPConnectionError
-from asciinema.urllib_http_adapter import URLLibHttpAdapter
+from . import __version__
+from .http_adapter import HTTPConnectionError
+from .urllib_http_adapter import URLLibHttpAdapter
 
 
 class APIError(Exception):
@@ -13,7 +16,13 @@ class APIError(Exception):
 
 
 class Api:
-    def __init__(self, url, user, install_id, http_adapter=None):
+    def __init__(
+        self,
+        url: str,
+        user: Optional[str],
+        install_id: str,
+        http_adapter: Any = None,
+    ) -> None:
         self.url = url
         self.user = user
         self.install_id = install_id
@@ -21,16 +30,16 @@ class Api:
             http_adapter if http_adapter is not None else URLLibHttpAdapter()
         )
 
-    def hostname(self):
+    def hostname(self: Api) -> Optional[str]:
         return urlparse(self.url).hostname
 
-    def auth_url(self):
+    def auth_url(self: Api) -> str:
         return f"{self.url}/connect/{self.install_id}"
 
-    def upload_url(self):
+    def upload_url(self: Api) -> str:
         return f"{self.url}/api/asciicasts"
 
-    def upload_asciicast(self, path):
+    def upload_asciicast(self: Api, path: str) -> Tuple[Any, Any]:
         with open(path, "rb") as f:
             try:
                 status, headers, body = self.http_adapter.post(
@@ -41,9 +50,9 @@ class Api:
                     password=self.install_id,
                 )
             except HTTPConnectionError as e:
-                raise APIError(str(e))
+                raise APIError(str(e)) from e
 
-        if status != 200 and status != 201:
+        if status in (200, 201):
             self._handle_error(status, body)
 
         if (headers.get("content-type") or "")[0:16] == "application/json":
@@ -53,10 +62,12 @@ class Api:
 
         return result, headers.get("Warning")
 
-    def _headers(self):
-        return {"User-Agent": self._user_agent(), "Accept": "application/json"}
+    def _headers(self) -> Dict[str, Union[Callable[[], str], str]]:
+        return {"user-Agent": self._user_agent, "accept": "application/json"}
 
-    def _user_agent(self):
+    @property
+    @staticmethod
+    def _user_agent() -> str:
         os = re.sub("([^-]+)-(.*)", "\\1/\\2", platform.platform())
 
         return (
@@ -64,11 +75,16 @@ class Api:
             f"/{platform.python_version()} {os}"
         )
 
-    def _handle_error(self, status, body):
+    @staticmethod
+    def _handle_error(status: int, body: str) -> None:
         errors = {
             400: f"Invalid request: {body}",
             401: "Invalid or revoked install ID",
-            404: "API endpoint not found. This asciinema version may no longer be supported. Please upgrade to the latest version.",
+            404: (
+                "API endpoint not found. "
+                "This asciinema version may no longer be supported. "
+                "Please upgrade to the latest version."
+            ),
             413: "Sorry, your asciicast is too big.",
             422: f"Invalid asciicast: {body}",
             503: "The server is down for maintenance. Try again in a minute.",
@@ -78,8 +94,11 @@ class Api:
 
         if not error:
             if status >= 500:
-                error = "The server is having temporary problems. Try again in a minute."
+                error = (
+                    "The server is having temporary problems. "
+                    "Try again in a minute."
+                )
             else:
-                error = "HTTP status: %i" % status
+                error = f"HTTP status: {status}"
 
         raise APIError(error)

--- a/asciinema/api.py
+++ b/asciinema/api.py
@@ -25,10 +25,10 @@ class Api:
         return urlparse(self.url).hostname
 
     def auth_url(self):
-        return "{}/connect/{}".format(self.url, self.install_id)
+        return f"{self.url}/connect/{self.install_id}"
 
     def upload_url(self):
-        return "{}/api/asciicasts".format(self.url)
+        return f"{self.url}/api/asciicasts"
 
     def upload_asciicast(self, path):
         with open(path, "rb") as f:
@@ -59,20 +59,18 @@ class Api:
     def _user_agent(self):
         os = re.sub("([^-]+)-(.*)", "\\1/\\2", platform.platform())
 
-        return "asciinema/%s %s/%s %s" % (
-            __version__,
-            platform.python_implementation(),
-            platform.python_version(),
-            os,
+        return (
+            f"asciinema/{__version__} {platform.python_implementation()}"
+            f"/{platform.python_version()} {os}"
         )
 
     def _handle_error(self, status, body):
         errors = {
-            400: "Invalid request: %s" % body,
+            400: f"Invalid request: {body}",
             401: "Invalid or revoked install ID",
             404: "API endpoint not found. This asciinema version may no longer be supported. Please upgrade to the latest version.",
             413: "Sorry, your asciicast is too big.",
-            422: "Invalid asciicast: %s" % body,
+            422: f"Invalid asciicast: {body}",
             503: "The server is down for maintenance. Try again in a minute.",
         }
 

--- a/asciinema/api.py
+++ b/asciinema/api.py
@@ -1,11 +1,11 @@
+import json
 import platform
 import re
-import json
 from urllib.parse import urlparse
 
 from asciinema import __version__
-from asciinema.urllib_http_adapter import URLLibHttpAdapter
 from asciinema.http_adapter import HTTPConnectionError
+from asciinema.urllib_http_adapter import URLLibHttpAdapter
 
 
 class APIError(Exception):
@@ -13,12 +13,13 @@ class APIError(Exception):
 
 
 class Api:
-
     def __init__(self, url, user, install_id, http_adapter=None):
         self.url = url
         self.user = user
         self.install_id = install_id
-        self.http_adapter = http_adapter if http_adapter is not None else URLLibHttpAdapter()
+        self.http_adapter = (
+            http_adapter if http_adapter is not None else URLLibHttpAdapter()
+        )
 
     def hostname(self):
         return urlparse(self.url).hostname
@@ -30,14 +31,14 @@ class Api:
         return "{}/api/asciicasts".format(self.url)
 
     def upload_asciicast(self, path):
-        with open(path, 'rb') as f:
+        with open(path, "rb") as f:
             try:
                 status, headers, body = self.http_adapter.post(
                     self.upload_url(),
                     files={"asciicast": ("ascii.cast", f)},
                     headers=self._headers(),
                     username=self.user,
-                    password=self.install_id
+                    password=self.install_id,
                 )
             except HTTPConnectionError as e:
                 raise APIError(str(e))
@@ -45,24 +46,25 @@ class Api:
         if status != 200 and status != 201:
             self._handle_error(status, body)
 
-        if (headers.get('content-type') or '')[0:16] == 'application/json':
+        if (headers.get("content-type") or "")[0:16] == "application/json":
             result = json.loads(body)
         else:
-            result = {'url': body}
+            result = {"url": body}
 
-        return result, headers.get('Warning')
+        return result, headers.get("Warning")
 
     def _headers(self):
-        return {'User-Agent': self._user_agent(), 'Accept': 'application/json'}
+        return {"User-Agent": self._user_agent(), "Accept": "application/json"}
 
     def _user_agent(self):
-        os = re.sub('([^-]+)-(.*)', '\\1/\\2', platform.platform())
+        os = re.sub("([^-]+)-(.*)", "\\1/\\2", platform.platform())
 
-        return 'asciinema/%s %s/%s %s' % (__version__,
-                                          platform.python_implementation(),
-                                          platform.python_version(),
-                                          os
-                                          )
+        return "asciinema/%s %s/%s %s" % (
+            __version__,
+            platform.python_implementation(),
+            platform.python_version(),
+            os,
+        )
 
     def _handle_error(self, status, body):
         errors = {
@@ -71,7 +73,7 @@ class Api:
             404: "API endpoint not found. This asciinema version may no longer be supported. Please upgrade to the latest version.",
             413: "Sorry, your asciicast is too big.",
             422: "Invalid asciicast: %s" % body,
-            503: "The server is down for maintenance. Try again in a minute."
+            503: "The server is down for maintenance. Try again in a minute.",
         }
 
         error = errors.get(status)

--- a/asciinema/api.py
+++ b/asciinema/api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import platform
 import re
@@ -30,17 +28,17 @@ class Api:
             http_adapter if http_adapter is not None else URLLibHttpAdapter()
         )
 
-    def hostname(self: Api) -> Optional[str]:
+    def hostname(self) -> Optional[str]:
         return urlparse(self.url).hostname
 
-    def auth_url(self: Api) -> str:
+    def auth_url(self) -> str:
         return f"{self.url}/connect/{self.install_id}"
 
-    def upload_url(self: Api) -> str:
+    def upload_url(self) -> str:
         return f"{self.url}/api/asciicasts"
 
-    def upload_asciicast(self: Api, path: str) -> Tuple[Any, Any]:
-        with open(path, "rb") as f:
+    def upload_asciicast(self, path_: str) -> Tuple[Any, Any]:
+        with open(path_, "rb") as f:
             try:
                 status, headers, body = self.http_adapter.post(
                     self.upload_url(),

--- a/asciinema/api.py
+++ b/asciinema/api.py
@@ -61,7 +61,7 @@ class Api:
         return result, headers.get("Warning")
 
     def _headers(self) -> Dict[str, Union[Callable[[], str], str]]:
-        return {"user-Agent": self._user_agent, "accept": "application/json"}
+        return {"user-agent": self._user_agent, "accept": "application/json"}
 
     @property
     @staticmethod

--- a/asciinema/asciicast/__init__.py
+++ b/asciinema/asciicast/__init__.py
@@ -40,9 +40,9 @@ def open_url(url):
         return sys.stdin
 
     if url.startswith("ipfs://"):
-        url = "https://ipfs.io/ipfs/%s" % url[7:]
+        url = f"https://ipfs.io/ipfs/{url[7:]}"
     elif url.startswith("dweb:/ipfs/"):
-        url = "https://ipfs.io/%s" % url[5:]
+        url = f"https://ipfs.io/{url[5:]}"
 
     if url.startswith("http:") or url.startswith("https:"):
         req = Request(url)

--- a/asciinema/asciicast/__init__.py
+++ b/asciinema/asciicast/__init__.py
@@ -1,9 +1,11 @@
 import codecs
 import gzip
-import html.parser
 import os
 import sys
 import urllib.error
+from codecs import StreamReader
+from html.parser import HTMLParser
+from typing import Any, List, TextIO, Union
 from urllib.parse import urlparse, urlunparse
 from urllib.request import Request, urlopen
 
@@ -14,28 +16,37 @@ class LoadError(Exception):
     pass
 
 
-class Parser(html.parser.HTMLParser):
-    def __init__(self):
-        html.parser.HTMLParser.__init__(self)
+class Parser(HTMLParser):
+    def __init__(self) -> None:
+        HTMLParser.__init__(self)
         self.url = None
 
-    def handle_starttag(self, tag, attrs_list):
-        # look for <link rel="alternate" type="application/x-asciicast" href="https://...cast">
+    def error(self, message: str) -> None:
+        raise NotImplementedError(
+            "subclasses of ParserBase must override error()"
+            ", but HTMLParser does not"
+        )
+
+    def handle_starttag(self, tag: str, attrs: List[Any]) -> None:
+        # look for <link rel="alternate"
+        #                type="application/x-asciicast"
+        #                href="https://...cast">
         if tag == "link":
-            attrs = {}
-            for k, v in attrs_list:
-                attrs[k] = v
+            # avoid modifying function signature keyword args from base class
+            _attrs = {}
+            for k, v in attrs:
+                _attrs[k] = v
 
-            if attrs.get("rel") == "alternate":
-                type = attrs.get("type")
-                if (
-                    type == "application/asciicast+json"
-                    or type == "application/x-asciicast"
+            if _attrs.get("rel") == "alternate":
+                type_ = _attrs.get("type")
+                if type_ in (
+                    "application/asciicast+json",
+                    "application/x-asciicast",
                 ):
-                    self.url = attrs.get("href")
+                    self.url = _attrs.get("href")
 
 
-def open_url(url):
+def open_url(url: str) -> Union[StreamReader, TextIO]:
     if url == "-":
         return sys.stdin
 
@@ -47,43 +58,46 @@ def open_url(url):
     if url.startswith("http:") or url.startswith("https:"):
         req = Request(url)
         req.add_header("Accept-Encoding", "gzip")
-        response = urlopen(req)
-        body = response
-        url = response.geturl()  # final URL after redirects
+        with urlopen(req) as response:
+            body = response
+            url = response.geturl()  # final URL after redirects
 
-        if response.headers["Content-Encoding"] == "gzip":
-            body = gzip.open(body)
+            if response.headers["Content-Encoding"] == "gzip":
+                body = gzip.open(body)
 
-        utf8_reader = codecs.getreader("utf-8")
-        content_type = response.headers["Content-Type"]
+            utf8_reader = codecs.getreader("utf-8")
+            content_type = response.headers["Content-Type"]
 
-        if content_type and content_type.startswith("text/html"):
-            html = utf8_reader(body, errors="replace").read()
-            parser = Parser()
-            parser.feed(html)
-            new_url = parser.url
+            if content_type and content_type.startswith("text/html"):
+                html = utf8_reader(body, errors="replace").read()
+                parser = Parser()
+                parser.feed(html)
+                new_url = parser.url
 
-            if not new_url:
-                raise LoadError(
-                    """<link rel="alternate" type="application/x-asciicast" href="..."> not found in fetched HTML document"""
-                )
-
-            if "://" not in new_url:
-                base_url = urlparse(url)
-
-                if new_url.startswith("/"):
-                    new_url = urlunparse(
-                        (base_url[0], base_url[1], new_url, "", "", "")
-                    )
-                else:
-                    path = os.path.dirname(base_url[2]) + "/" + new_url
-                    new_url = urlunparse(
-                        (base_url[0], base_url[1], path, "", "", "")
+                if not new_url:
+                    raise LoadError(
+                        '<link rel="alternate" '
+                        'type="application/x-asciicast" '
+                        'href="..."> '
+                        "not found in fetched HTML document"
                     )
 
-            return open_url(new_url)
+                if "://" not in new_url:
+                    base_url = urlparse(url)
 
-        return utf8_reader(body, errors="strict")
+                    if new_url.startswith("/"):
+                        new_url = urlunparse(
+                            (base_url[0], base_url[1], new_url, "", "", "")
+                        )
+                    else:
+                        path = f"{os.path.dirname(base_url[2])}/{new_url}"
+                        new_url = urlunparse(
+                            (base_url[0], base_url[1], path, "", "", "")
+                        )
+
+                return open_url(new_url)
+
+            return utf8_reader(body, errors="strict")
 
     return open(url, mode="rt", encoding="utf-8")
 
@@ -91,10 +105,12 @@ def open_url(url):
 class open_from_url:
     FORMAT_ERROR = "only asciicast v1 and v2 formats can be opened"
 
-    def __init__(self, url):
+    def __init__(self, url: str) -> None:
         self.url = url
+        self.file: Union[StreamReader, TextIO, None] = None
+        self.context: Any = None
 
-    def __enter__(self):
+    def __enter__(self) -> Any:
         try:
             self.file = open_url(self.url)
             first_line = self.file.readline()
@@ -106,11 +122,13 @@ class open_from_url:
                 try:  # try v1 next
                     self.context = v1.open_from_file(first_line, self.file)
                     return self.context.__enter__()
-                except v1.LoadError:
-                    raise LoadError(self.FORMAT_ERROR)
+                except v1.LoadError as e:
+                    raise LoadError(self.FORMAT_ERROR) from e
 
         except (OSError, urllib.error.HTTPError) as e:
-            raise LoadError(str(e))
+            raise LoadError(str(e)) from e
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(
+        self, exc_type: str, exc_value: str, exc_traceback: str
+    ) -> None:
         self.context.__exit__(exc_type, exc_value, exc_traceback)

--- a/asciinema/asciicast/events.py
+++ b/asciinema/asciicast/events.py
@@ -1,28 +1,41 @@
-def to_relative_time(events):
+from typing import Any, Generator, List, Optional
+
+
+def to_relative_time(
+    events: Generator[List[Any], None, None]
+) -> Generator[List[Any], None, None]:
     prev_time = 0
 
     for frame in events:
-        time, type, data = frame
+        time, type_, data = frame
         delay = time - prev_time
         prev_time = time
-        yield [delay, type, data]
+        yield [delay, type_, data]
 
 
-def to_absolute_time(events):
+def to_absolute_time(
+    events: Generator[List[Any], None, None]
+) -> Generator[List[Any], None, None]:
     time = 0
 
     for frame in events:
-        delay, type, data = frame
+        delay, type_, data = frame
         time = time + delay
-        yield [time, type, data]
+        yield [time, type_, data]
 
 
-def cap_relative_time(events, time_limit):
+def cap_relative_time(
+    events: Generator[List[Any], None, None], time_limit: Optional[float]
+) -> Generator[List[Any], None, None]:
     if time_limit:
-        return ([min(delay, time_limit), type, data] for delay, type, data in events)
-    else:
-        return events
+        return (
+            [min(delay, time_limit), type_, data]
+            for delay, type_, data in events
+        )
+    return events
 
 
-def adjust_speed(events, speed):
-    return ([delay / speed, type, data] for delay, type, data in events)
+def adjust_speed(
+    events: Generator[List[Any], None, None], speed: Any
+) -> Generator[List[Any], None, None]:
+    return ([delay / speed, type_, data] for delay, type_, data in events)

--- a/asciinema/asciicast/raw.py
+++ b/asciinema/asciicast/raw.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from os import path, stat
 from typing import IO, Any, Optional
 
@@ -23,7 +21,7 @@ class writer:
         self.file: Optional[IO[Any]] = None
         self.metadata = metadata
 
-    def __enter__(self) -> writer:
+    def __enter__(self) -> Any:
         self.file = open(self.path, mode=self.mode, buffering=self.buffering)
         return self
 

--- a/asciinema/asciicast/raw.py
+++ b/asciinema/asciicast/raw.py
@@ -1,25 +1,43 @@
-import os
+from __future__ import annotations
+
+from os import path, stat
+from typing import IO, Any, Optional
 
 
-class writer():
-
-    def __init__(self, path, metadata=None, append=False, buffering=0):
-        if append and os.path.exists(path) and os.stat(path).st_size == 0:  # true for pipes
+class writer:
+    def __init__(
+        self,
+        path_: str,
+        metadata: Any = None,
+        append: bool = False,
+        buffering: int = 0,
+    ) -> None:
+        if (
+            append and path.exists(path_) and stat(path_).st_size == 0
+        ):  # true for pipes
             append = False
 
-        self.path = path
+        self.path = path_
         self.buffering = buffering
-        self.mode = 'ab' if append else 'wb'
+        self.mode: str = "ab" if append else "wb"
+        self.file: Optional[IO[Any]] = None
+        self.metadata = metadata
 
-    def __enter__(self):
+    def __enter__(self) -> writer:
         self.file = open(self.path, mode=self.mode, buffering=self.buffering)
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(
+        self, exc_type: str, exc_value: str, exc_traceback: str
+    ) -> None:
+        assert self.file is not None
         self.file.close()
 
-    def write_stdout(self, ts, data):
+    def write_stdout(self, ts: float, data: Any) -> None:
+        _ = ts
+        assert self.file is not None
         self.file.write(data)
 
-    def write_stdin(self, ts, data):
+    # pylint: disable=no-self-use
+    def write_stdin(self, ts: float, data: Any) -> None:
         pass

--- a/asciinema/asciicast/v1.py
+++ b/asciinema/asciicast/v1.py
@@ -1,12 +1,13 @@
 import json
-import json.decoder
+from codecs import StreamReader
+from typing import Any, Dict, Generator, List, Optional, TextIO, Union
 
-from asciinema.asciicast.events import to_absolute_time
+from .events import to_absolute_time
 
 try:
-    JSONDecodeError = json.decoder.JSONDecodeError
-except AttributeError:
-    JSONDecodeError = ValueError
+    from json.decoder import JSONDecodeError
+except ImportError:
+    JSONDecodeError = ValueError  # type: ignore
 
 
 class LoadError(Exception):
@@ -14,13 +15,13 @@ class LoadError(Exception):
 
 
 class Asciicast:
-    def __init__(self, attrs):
-        self.version = 1
+    def __init__(self, attrs: Dict[str, Any]) -> None:
+        self.version: int = 1
         self.__attrs = attrs
         self.idle_time_limit = None  # v1 doesn't store it
 
     @property
-    def v2_header(self):
+    def v2_header(self) -> Dict[str, Any]:
         keys = ["width", "height", "duration", "command", "title", "env"]
         header = {
             k: v
@@ -29,34 +30,37 @@ class Asciicast:
         }
         return header
 
-    def __stdout_events(self):
+    def __stdout_events(self) -> Generator[List[Any], None, None]:
         for time, data in self.__attrs["stdout"]:
             yield [time, "o", data]
 
-    def events(self):
+    def events(self) -> Any:
         return self.stdout_events()
 
-    def stdout_events(self):
+    def stdout_events(self) -> Generator[List[Any], None, None]:
         return to_absolute_time(self.__stdout_events())
 
 
 class open_from_file:
-    FORMAT_ERROR = "only asciicast v1 format can be opened"
+    FORMAT_ERROR: str = "only asciicast v1 format can be opened"
 
-    def __init__(self, first_line, file):
+    def __init__(
+        self, first_line: str, file: Union[TextIO, StreamReader]
+    ) -> None:
         self.first_line = first_line
         self.file = file
 
-    def __enter__(self):
+    def __enter__(self) -> Optional[Asciicast]:
         try:
             attrs = json.loads(self.first_line + self.file.read())
 
             if attrs.get("version") == 1:
                 return Asciicast(attrs)
-            else:
-                raise LoadError(self.FORMAT_ERROR)
-        except JSONDecodeError:
             raise LoadError(self.FORMAT_ERROR)
+        except JSONDecodeError as e:
+            raise LoadError(self.FORMAT_ERROR) from e
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(
+        self, exc_type: str, exc_value: str, exc_traceback: str
+    ) -> None:
         self.file.close()

--- a/asciinema/asciicast/v1.py
+++ b/asciinema/asciicast/v1.py
@@ -3,7 +3,6 @@ import json.decoder
 
 from asciinema.asciicast.events import to_absolute_time
 
-
 try:
     JSONDecodeError = json.decoder.JSONDecodeError
 except AttributeError:
@@ -15,7 +14,6 @@ class LoadError(Exception):
 
 
 class Asciicast:
-
     def __init__(self, attrs):
         self.version = 1
         self.__attrs = attrs
@@ -23,13 +21,17 @@ class Asciicast:
 
     @property
     def v2_header(self):
-        keys = ['width', 'height', 'duration', 'command', 'title', 'env']
-        header = {k: v for k, v in self.__attrs.items() if k in keys and v is not None}
+        keys = ["width", "height", "duration", "command", "title", "env"]
+        header = {
+            k: v
+            for k, v in self.__attrs.items()
+            if k in keys and v is not None
+        }
         return header
 
     def __stdout_events(self):
-        for time, data in self.__attrs['stdout']:
-            yield [time, 'o', data]
+        for time, data in self.__attrs["stdout"]:
+            yield [time, "o", data]
 
     def events(self):
         return self.stdout_events()
@@ -38,7 +40,7 @@ class Asciicast:
         return to_absolute_time(self.__stdout_events())
 
 
-class open_from_file():
+class open_from_file:
     FORMAT_ERROR = "only asciicast v1 format can be opened"
 
     def __init__(self, first_line, file):
@@ -49,11 +51,11 @@ class open_from_file():
         try:
             attrs = json.loads(self.first_line + self.file.read())
 
-            if attrs.get('version') == 1:
+            if attrs.get("version") == 1:
                 return Asciicast(attrs)
             else:
                 raise LoadError(self.FORMAT_ERROR)
-        except JSONDecodeError as e:
+        except JSONDecodeError:
             raise LoadError(self.FORMAT_ERROR)
 
     def __exit__(self, exc_type, exc_value, exc_traceback):

--- a/asciinema/asciicast/v2.py
+++ b/asciinema/asciicast/v2.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 import codecs
 import json
-import json.decoder
-
-try:
-    JSONDecodeError = json.decoder.JSONDecodeError
-except AttributeError:
-    JSONDecodeError = ValueError
+from codecs import StreamReader
+from io import IOBase
+from json.decoder import JSONDecodeError
+from typing import IO, Any, Dict, Generator, List, Optional, TextIO, Union
 
 
 class LoadError(Exception):
@@ -13,88 +13,97 @@ class LoadError(Exception):
 
 
 class Asciicast:
-    def __init__(self, f, header):
-        self.version = 2
+    def __init__(
+        self, f: Union[TextIO, StreamReader], header: Dict[str, Any]
+    ) -> None:
+        self.version: int = 2
         self.__file = f
         self.v2_header = header
         self.idle_time_limit = header.get("idle_time_limit")
 
-    def events(self):
+    def events(self) -> Generator[Any, None, None]:
         for line in self.__file:
             yield json.loads(line)
 
-    def stdout_events(self):
-        for time, type, data in self.events():
-            if type == "o":
-                yield [time, type, data]
+    def stdout_events(self) -> Generator[List[Any], None, None]:
+        for time, type_, data in self.events():
+            if type_ == "o":
+                yield [time, type_, data]
 
 
-def build_from_header_and_file(header, f):
+def build_from_header_and_file(
+    header: Dict[str, Any], f: Union[StreamReader, TextIO]
+) -> Asciicast:
     return Asciicast(f, header)
 
 
 class open_from_file:
     FORMAT_ERROR = "only asciicast v2 format can be opened"
 
-    def __init__(self, first_line, file):
+    def __init__(
+        self, first_line: str, file: Union[StreamReader, TextIO]
+    ) -> None:
         self.first_line = first_line
         self.file = file
 
-    def __enter__(self):
+    def __enter__(self) -> Optional[Asciicast]:
         try:
-            v2_header = json.loads(self.first_line)
+            v2_header: Dict[str, Any] = json.loads(self.first_line)
             if v2_header.get("version") == 2:
                 return build_from_header_and_file(v2_header, self.file)
-            else:
-                raise LoadError(self.FORMAT_ERROR)
-        except JSONDecodeError:
             raise LoadError(self.FORMAT_ERROR)
+        except JSONDecodeError as e:
+            raise LoadError(self.FORMAT_ERROR) from e
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(
+        self, exc_type: str, exc_value: str, exc_traceback: str
+    ) -> None:
         self.file.close()
 
 
-def get_duration(path):
-    with open(path, mode="rt", encoding="utf-8") as f:
+def get_duration(path_: str) -> Any:
+    with open(path_, mode="rt", encoding="utf-8") as f:
         first_line = f.readline()
         with open_from_file(first_line, f) as a:
+            assert isinstance(a, Asciicast)
+            last_frame = None
             for last_frame in a.stdout_events():
                 pass
             return last_frame[0]
 
 
-def build_header(width, height, metadata):
+def build_header(
+    width: Optional[int], height: Optional[int], metadata: Any
+) -> Dict[str, Any]:
     header = {"version": 2, "width": width, "height": height}
     header.update(metadata)
 
     assert "width" in header, "width missing in metadata"
     assert "height" in header, "height missing in metadata"
-    assert type(header["width"]) == int
-    assert type(header["height"]) == int
+    assert isinstance(header["width"], int)
+    assert isinstance(header["height"], int)
 
     if "timestamp" in header:
-        assert (
-            type(header["timestamp"]) == int
-            or type(header["timestamp"]) == float
-        )
+        assert isinstance(header["timestamp"], (int, float))
 
     return header
 
 
 class writer:
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
-        path,
-        metadata=None,
-        append=False,
-        buffering=1,
-        width=None,
-        height=None,
-    ):
+        path: str,
+        metadata: Any = None,
+        append: bool = False,
+        buffering: int = 1,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ) -> None:
         self.path = path
         self.buffering = buffering
         self.stdin_decoder = codecs.getincrementaldecoder("UTF-8")("replace")
         self.stdout_decoder = codecs.getincrementaldecoder("UTF-8")("replace")
+        self.file: Optional[IO[Any]] = None
 
         if append:
             self.mode = "a"
@@ -103,34 +112,43 @@ class writer:
             self.mode = "w"
             self.header = build_header(width, height, metadata or {})
 
-    def __enter__(self):
-        self.file = open(self.path, mode=self.mode, buffering=self.buffering)
+    def __enter__(self) -> writer:
+        self.file = open(
+            self.path,
+            mode=self.mode,
+            buffering=self.buffering,
+            encoding="utf-8",
+        )
 
         if self.header:
             self.__write_line(self.header)
 
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(
+        self, exc_type: str, exc_value: str, exc_traceback: str
+    ) -> None:
+        assert isinstance(self.file, IOBase)
         self.file.close()
 
-    def write_stdout(self, ts, data):
-        if type(data) == str:
+    def write_stdout(self, ts: float, data: Union[str, bytes]) -> None:
+        if isinstance(data, str):
             data = data.encode(encoding="utf-8", errors="strict")
         data = self.stdout_decoder.decode(data)
         self.__write_event(ts, "o", data)
 
-    def write_stdin(self, ts, data):
-        if type(data) == str:
+    def write_stdin(self, ts: float, data: Union[str, bytes]) -> None:
+        if isinstance(data, str):
             data = data.encode(encoding="utf-8", errors="strict")
         data = self.stdin_decoder.decode(data)
         self.__write_event(ts, "i", data)
 
-    def __write_event(self, ts, etype, data):
+    def __write_event(self, ts: float, etype: str, data: str) -> None:
         self.__write_line([round(ts, 6), etype, data])
 
-    def __write_line(self, obj):
+    def __write_line(self, obj: Any) -> None:
         line = json.dumps(
             obj, ensure_ascii=False, indent=None, separators=(", ", ": ")
         )
-        self.file.write(line + "\n")
+        assert isinstance(self.file, IOBase)
+        self.file.write(f"{line}\n")

--- a/asciinema/asciicast/v2.py
+++ b/asciinema/asciicast/v2.py
@@ -1,7 +1,6 @@
+import codecs
 import json
 import json.decoder
-import time
-import codecs
 
 try:
     JSONDecodeError = json.decoder.JSONDecodeError
@@ -14,12 +13,11 @@ class LoadError(Exception):
 
 
 class Asciicast:
-
     def __init__(self, f, header):
         self.version = 2
         self.__file = f
         self.v2_header = header
-        self.idle_time_limit = header.get('idle_time_limit')
+        self.idle_time_limit = header.get("idle_time_limit")
 
     def events(self):
         for line in self.__file:
@@ -27,7 +25,7 @@ class Asciicast:
 
     def stdout_events(self):
         for time, type, data in self.events():
-            if type == 'o':
+            if type == "o":
                 yield [time, type, data]
 
 
@@ -35,7 +33,7 @@ def build_from_header_and_file(header, f):
     return Asciicast(f, header)
 
 
-class open_from_file():
+class open_from_file:
     FORMAT_ERROR = "only asciicast v2 format can be opened"
 
     def __init__(self, first_line, file):
@@ -45,11 +43,11 @@ class open_from_file():
     def __enter__(self):
         try:
             v2_header = json.loads(self.first_line)
-            if v2_header.get('version') == 2:
+            if v2_header.get("version") == 2:
                 return build_from_header_and_file(v2_header, self.file)
             else:
                 raise LoadError(self.FORMAT_ERROR)
-        except JSONDecodeError as e:
+        except JSONDecodeError:
             raise LoadError(self.FORMAT_ERROR)
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
@@ -57,7 +55,7 @@ class open_from_file():
 
 
 def get_duration(path):
-    with open(path, mode='rt', encoding='utf-8') as f:
+    with open(path, mode="rt", encoding="utf-8") as f:
         first_line = f.readline()
         with open_from_file(first_line, f) as a:
             for last_frame in a.stdout_events():
@@ -66,33 +64,43 @@ def get_duration(path):
 
 
 def build_header(width, height, metadata):
-    header = {'version': 2, 'width': width, 'height': height}
+    header = {"version": 2, "width": width, "height": height}
     header.update(metadata)
 
-    assert 'width' in header, 'width missing in metadata'
-    assert 'height' in header, 'height missing in metadata'
-    assert type(header['width']) == int
-    assert type(header['height']) == int
+    assert "width" in header, "width missing in metadata"
+    assert "height" in header, "height missing in metadata"
+    assert type(header["width"]) == int
+    assert type(header["height"]) == int
 
-    if 'timestamp' in header:
-        assert type(header['timestamp']) == int or type(header['timestamp']) == float
+    if "timestamp" in header:
+        assert (
+            type(header["timestamp"]) == int
+            or type(header["timestamp"]) == float
+        )
 
     return header
 
 
-class writer():
-
-    def __init__(self, path, metadata=None, append=False, buffering=1, width=None, height=None):
+class writer:
+    def __init__(
+        self,
+        path,
+        metadata=None,
+        append=False,
+        buffering=1,
+        width=None,
+        height=None,
+    ):
         self.path = path
         self.buffering = buffering
-        self.stdin_decoder = codecs.getincrementaldecoder('UTF-8')('replace')
-        self.stdout_decoder = codecs.getincrementaldecoder('UTF-8')('replace')
+        self.stdin_decoder = codecs.getincrementaldecoder("UTF-8")("replace")
+        self.stdout_decoder = codecs.getincrementaldecoder("UTF-8")("replace")
 
         if append:
-            self.mode = 'a'
+            self.mode = "a"
             self.header = None
         else:
-            self.mode = 'w'
+            self.mode = "w"
             self.header = build_header(width, height, metadata or {})
 
     def __enter__(self):
@@ -108,19 +116,21 @@ class writer():
 
     def write_stdout(self, ts, data):
         if type(data) == str:
-            data = data.encode(encoding='utf-8', errors='strict')
+            data = data.encode(encoding="utf-8", errors="strict")
         data = self.stdout_decoder.decode(data)
-        self.__write_event(ts, 'o', data)
+        self.__write_event(ts, "o", data)
 
     def write_stdin(self, ts, data):
         if type(data) == str:
-            data = data.encode(encoding='utf-8', errors='strict')
+            data = data.encode(encoding="utf-8", errors="strict")
         data = self.stdin_decoder.decode(data)
-        self.__write_event(ts, 'i', data)
+        self.__write_event(ts, "i", data)
 
     def __write_event(self, ts, etype, data):
         self.__write_line([round(ts, 6), etype, data])
 
     def __write_line(self, obj):
-        line = json.dumps(obj, ensure_ascii=False, indent=None, separators=(', ', ': '))
-        self.file.write(line + '\n')
+        line = json.dumps(
+            obj, ensure_ascii=False, indent=None, separators=(", ", ": ")
+        )
+        self.file.write(line + "\n")

--- a/asciinema/asciicast/v2.py
+++ b/asciinema/asciicast/v2.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import codecs
 import json
 from codecs import StreamReader
@@ -112,7 +110,7 @@ class writer:
             self.mode = "w"
             self.header = build_header(width, height, metadata or {})
 
-    def __enter__(self) -> writer:
+    def __enter__(self) -> Any:
         self.file = open(
             self.path,
             mode=self.mode,

--- a/asciinema/async_worker.py
+++ b/asciinema/async_worker.py
@@ -3,14 +3,13 @@ try:
     # multiprocessing does not work (python issue 3770)
     # and cause an ImportError. Otherwise it will happen
     # later when trying to use Queue().
-    from multiprocessing import synchronize, Process, Queue
+    from multiprocessing import Process, Queue
 except ImportError:
-    from threading import Thread as Process
     from queue import Queue
+    from threading import Thread as Process
 
 
-class async_worker():
-
+class async_worker:
     def __init__(self):
         self.queue = Queue()
 

--- a/asciinema/async_worker.py
+++ b/asciinema/async_worker.py
@@ -1,22 +1,17 @@
-from __future__ import annotations
+from typing import Any, Optional
 
-from typing import TYPE_CHECKING, Any, Optional
+try:
+    # Importing synchronize is to detect platforms where
+    # multiprocessing does not work (python issue 3770)
+    # and cause an ImportError. Otherwise it will happen
+    # later when trying to use Queue().
+    from multiprocessing import Process, Queue, synchronize
 
-if TYPE_CHECKING:
-    from multiprocessing import Process, Queue
-else:
-    try:
-        # Importing synchronize is to detect platforms where
-        # multiprocessing does not work (python issue 3770)
-        # and cause an ImportError. Otherwise it will happen
-        # later when trying to use Queue().
-        from multiprocessing import Process, Queue, synchronize
-
-        # pylint: disable=pointless-statement
-        lambda _=synchronize: None  # avoid pruning import
-    except ImportError:
-        from queue import Queue
-        from threading import Thread as Process
+    # pylint: disable=pointless-statement
+    lambda _=synchronize: None  # avoid pruning import
+except ImportError:
+    from queue import Queue  # type: ignore
+    from threading import Thread as Process  # type: ignore
 
 
 class async_worker:
@@ -24,7 +19,7 @@ class async_worker:
         self.queue: Queue[Any] = Queue()
         self.process: Optional[Process] = None
 
-    def __enter__(self) -> async_worker:
+    def __enter__(self) -> Any:
         self.process = Process(target=self.run)
         self.process.start()
         return self

--- a/asciinema/async_worker.py
+++ b/asciinema/async_worker.py
@@ -1,30 +1,46 @@
-try:
-    # Importing synchronize is to detect platforms where
-    # multiprocessing does not work (python issue 3770)
-    # and cause an ImportError. Otherwise it will happen
-    # later when trying to use Queue().
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
     from multiprocessing import Process, Queue
-except ImportError:
-    from queue import Queue
-    from threading import Thread as Process
+else:
+    try:
+        # Importing synchronize is to detect platforms where
+        # multiprocessing does not work (python issue 3770)
+        # and cause an ImportError. Otherwise it will happen
+        # later when trying to use Queue().
+        from multiprocessing import Process, Queue, synchronize
+
+        # pylint: disable=pointless-statement
+        lambda _=synchronize: None  # avoid pruning import
+    except ImportError:
+        from queue import Queue
+        from threading import Thread as Process
 
 
 class async_worker:
-    def __init__(self):
-        self.queue = Queue()
+    def __init__(self) -> None:
+        self.queue: Queue[Any] = Queue()
+        self.process: Optional[Process] = None
 
-    def __enter__(self):
+    def __enter__(self) -> async_worker:
         self.process = Process(target=self.run)
         self.process.start()
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(
+        self, exc_type: str, exc_value: str, exc_traceback: str
+    ) -> None:
         self.queue.put(None)
+        assert isinstance(self.process, Process)
         self.process.join()
 
-    def enqueue(self, payload):
+    def enqueue(self, payload: Any) -> None:
         self.queue.put(payload)
 
-    def run(self):
+    def run(self) -> None:
+        payload: Any
         for payload in iter(self.queue.get, None):
-            self.perform(payload)
+            # pylint: disable=no-member
+            self.perform(payload)  # type: ignore[attr-defined]

--- a/asciinema/commands/auth.py
+++ b/asciinema/commands/auth.py
@@ -2,15 +2,16 @@ from asciinema.commands.command import Command
 
 
 class AuthCommand(Command):
-
     def __init__(self, args, config, env):
         Command.__init__(self, args, config, env)
 
     def execute(self):
-        self.print('Open the following URL in a web browser to link your '
-                   'install ID with your %s user account:\n\n'
-                   '%s\n\n'
-                   'This will associate all recordings uploaded from this machine '
-                   '(past and future ones) to your account, '
-                   'and allow you to manage them (change title/theme, delete) at %s.'
-                   % (self.api.hostname(), self.api.auth_url(), self.api.hostname()))
+        self.print(
+            f"Open the following URL in a web browser to link your install ID "
+            f"with your {self.api.hostname()} user account:\n\n"
+            f"{self.api.auth_url()}\n\n"
+            "This will associate all recordings uploaded from this machine "
+            "(past and future ones) to your account"
+            ", and allow you to manage them (change title/theme, delete) at "
+            f"{self.api.hostname()}."
+        )

--- a/asciinema/commands/auth.py
+++ b/asciinema/commands/auth.py
@@ -1,11 +1,14 @@
-from asciinema.commands.command import Command
+from typing import Any, Dict
+
+from ..config import Config
+from .command import Command
 
 
 class AuthCommand(Command):
-    def __init__(self, args, config, env):
+    def __init__(self, args: Any, config: Config, env: Dict[str, str]) -> None:
         Command.__init__(self, args, config, env)
 
-    def execute(self):
+    def execute(self) -> None:
         self.print(
             f"Open the following URL in a web browser to link your install ID "
             f"with your {self.api.hostname()} user account:\n\n"

--- a/asciinema/commands/cat.py
+++ b/asciinema/commands/cat.py
@@ -1,23 +1,25 @@
 import sys
+from typing import Any, Dict
 
-import asciinema.asciicast as asciicast
-from asciinema.commands.command import Command
-from asciinema.term import raw
+from .. import asciicast
+from ..config import Config
+from ..term import raw
+from .command import Command
 
 
 class CatCommand(Command):
-    def __init__(self, args, config, env):
+    def __init__(self, args: Any, config: Config, env: Dict[str, str]):
         Command.__init__(self, args, config, env)
         self.filename = args.filename
 
-    def execute(self):
+    def execute(self) -> int:
         try:
-            stdin = open("/dev/tty")
-            with raw(stdin.fileno()):
-                with asciicast.open_from_url(self.filename) as a:
-                    for t, _type, text in a.stdout_events():
-                        sys.stdout.write(text)
-                        sys.stdout.flush()
+            with open("/dev/tty", "wt", encoding="utf-8") as stdin:
+                with raw(stdin.fileno()):
+                    with asciicast.open_from_url(self.filename) as a:
+                        for _, _type, text in a.stdout_events():
+                            sys.stdout.write(text)
+                            sys.stdout.flush()
 
         except asciicast.LoadError as e:
             self.print_error(f"printing failed: {str(e)}")

--- a/asciinema/commands/cat.py
+++ b/asciinema/commands/cat.py
@@ -20,7 +20,7 @@ class CatCommand(Command):
                         sys.stdout.flush()
 
         except asciicast.LoadError as e:
-            self.print_error("printing failed: %s" % str(e))
+            self.print_error(f"printing failed: {str(e)}")
             return 1
 
         return 0

--- a/asciinema/commands/cat.py
+++ b/asciinema/commands/cat.py
@@ -1,19 +1,18 @@
 import sys
 
+import asciinema.asciicast as asciicast
 from asciinema.commands.command import Command
 from asciinema.term import raw
-import asciinema.asciicast as asciicast
 
 
 class CatCommand(Command):
-
     def __init__(self, args, config, env):
         Command.__init__(self, args, config, env)
         self.filename = args.filename
 
     def execute(self):
         try:
-            stdin = open('/dev/tty')
+            stdin = open("/dev/tty")
             with raw(stdin.fileno()):
                 with asciicast.open_from_url(self.filename) as a:
                     for t, _type, text in a.stdout_events():

--- a/asciinema/commands/command.py
+++ b/asciinema/commands/command.py
@@ -1,24 +1,32 @@
 import sys
+from typing import Any, Dict, TextIO
 
-from asciinema.api import Api
+from ..api import Api
+from ..config import Config
 
 
 class Command:
-    def __init__(self, args, config, env):
-        self.quiet = False
+    def __init__(self, _args: Any, config: Config, env: Dict[str, str]):
+        self.quiet: bool = False
         self.api = Api(config.api_url, env.get("USER"), config.install_id)
 
-    def print(self, text, file=sys.stdout, end="\n", force=False):
+    def print(
+        self,
+        text: str,
+        file_: TextIO = sys.stdout,
+        end: str = "\n",
+        force: bool = False,
+    ) -> None:
         if not self.quiet or force:
-            print(text, file=file, end=end)
+            print(text, file=file_, end=end)
 
-    def print_info(self, text):
+    def print_info(self, text: str) -> None:
         self.print(f"[0;32masciinema: {text}[0m")
 
-    def print_warning(self, text):
+    def print_warning(self, text: str) -> None:
         self.print(f"[0;33masciinema: {text}[0m")
 
-    def print_error(self, text):
+    def print_error(self, text: str) -> None:
         self.print(
-            f"[0;31masciinema: {text}[0m", file=sys.stderr, force=True
+            f"[0;31masciinema: {text}[0m", file_=sys.stderr, force=True
         )

--- a/asciinema/commands/command.py
+++ b/asciinema/commands/command.py
@@ -4,7 +4,6 @@ from asciinema.api import Api
 
 
 class Command:
-
     def __init__(self, args, config, env):
         self.quiet = False
         self.api = Api(config.api_url, env.get("USER"), config.install_id)
@@ -14,10 +13,12 @@ class Command:
             print(text, file=file, end=end)
 
     def print_info(self, text):
-        self.print("\x1b[0;32masciinema: %s\x1b[0m" % text)
+        self.print(f"[0;32masciinema: {text}[0m")
 
     def print_warning(self, text):
-        self.print("\x1b[0;33masciinema: %s\x1b[0m" % text)
+        self.print(f"[0;33masciinema: {text}[0m")
 
     def print_error(self, text):
-        self.print("\x1b[0;31masciinema: %s\x1b[0m" % text, file=sys.stderr, force=True)
+        self.print(
+            f"[0;31masciinema: {text}[0m", file=sys.stderr, force=True
+        )

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -23,7 +23,7 @@ class PlayCommand(Command):
                 )
 
         except asciicast.LoadError as e:
-            self.print_error("playback failed: %s" % str(e))
+            self.print_error(f"playback failed: {str(e)}")
             return 1
         except KeyboardInterrupt:
             return 1

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -1,10 +1,19 @@
-import asciinema.asciicast as asciicast
-from asciinema.commands.command import Command
-from asciinema.player import Player
+from typing import Any, Dict, Optional
+
+from .. import asciicast
+from ..commands.command import Command
+from ..config import Config
+from ..player import Player
 
 
 class PlayCommand(Command):
-    def __init__(self, args, config, env, player=None):
+    def __init__(
+        self,
+        args: Any,
+        config: Config,
+        env: Dict[str, str],
+        player: Optional[Player] = None,
+    ) -> None:
         Command.__init__(self, args, config, env)
         self.filename = args.filename
         self.idle_time_limit = args.idle_time_limit
@@ -15,7 +24,7 @@ class PlayCommand(Command):
             "step": config.play_step_key,
         }
 
-    def execute(self):
+    def execute(self) -> int:
         try:
             with asciicast.open_from_url(self.filename) as a:
                 self.player.play(

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -1,10 +1,9 @@
+import asciinema.asciicast as asciicast
 from asciinema.commands.command import Command
 from asciinema.player import Player
-import asciinema.asciicast as asciicast
 
 
 class PlayCommand(Command):
-
     def __init__(self, args, config, env, player=None):
         Command.__init__(self, args, config, env)
         self.filename = args.filename
@@ -12,14 +11,16 @@ class PlayCommand(Command):
         self.speed = args.speed
         self.player = player if player is not None else Player()
         self.key_bindings = {
-            'pause': config.play_pause_key,
-            'step': config.play_step_key
+            "pause": config.play_pause_key,
+            "step": config.play_step_key,
         }
 
     def execute(self):
         try:
             with asciicast.open_from_url(self.filename) as a:
-                self.player.play(a, self.idle_time_limit, self.speed, self.key_bindings)
+                self.player.play(
+                    a, self.idle_time_limit, self.speed, self.key_bindings
+                )
 
         except asciicast.LoadError as e:
             self.print_error("playback failed: %s" % str(e))

--- a/asciinema/commands/record.py
+++ b/asciinema/commands/record.py
@@ -50,7 +50,7 @@ class RecordCommand(Command):
 
         if os.path.exists(self.filename):
             if not os.access(self.filename, os.W_OK):
-                self.print_error("can't write to %s" % self.filename)
+                self.print_error(f"can't write to {self.filename}")
                 return 1
 
             if os.stat(self.filename).st_size > 0 and self.overwrite:
@@ -58,7 +58,7 @@ class RecordCommand(Command):
                 append = False
 
             elif os.stat(self.filename).st_size > 0 and not append:
-                self.print_error("%s already exists, aborting" % self.filename)
+                self.print_error(f"{self.filename} already exists, aborting")
                 self.print_error(
                     "use --overwrite option if you want to overwrite existing recording"
                 )
@@ -68,9 +68,9 @@ class RecordCommand(Command):
                 return 1
 
         if append:
-            self.print_info("appending to asciicast at %s" % self.filename)
+            self.print_info(f"appending to asciicast at {self.filename}")
         else:
-            self.print_info("recording asciicast to %s" % self.filename)
+            self.print_info(f"recording asciicast to {self.filename}")
 
         if self.command:
             self.print_info("""exit opened program when you're done""")
@@ -108,14 +108,14 @@ class RecordCommand(Command):
         if upload:
             if not self.assume_yes:
                 self.print_info(
-                    "press <enter> to upload to %s, <ctrl-c> to save locally"
-                    % self.api.hostname()
+                    f"press <enter> to upload to {self.api.hostname()}"
+                    ", <ctrl-c> to save locally"
                 )
                 try:
                     sys.stdin.readline()
                 except KeyboardInterrupt:
                     self.print("\r", end="")
-                    self.print_info("asciicast saved to %s" % self.filename)
+                    self.print_info(f"asciicast saved to {self.filename}")
                     return 0
 
             try:
@@ -129,14 +129,13 @@ class RecordCommand(Command):
 
             except APIError as e:
                 self.print("\r\x1b[A", end="")
-                self.print_error("upload failed: %s" % str(e))
+                self.print_error(f"upload failed: {str(e)}")
                 self.print_error(
-                    "retry later by running: asciinema upload %s"
-                    % self.filename
+                    f"retry later by running: asciinema upload {self.filename}"
                 )
                 return 1
         else:
-            self.print_info("asciicast saved to %s" % self.filename)
+            self.print_info(f"asciicast saved to {self.filename}")
 
         return 0
 

--- a/asciinema/commands/record.py
+++ b/asciinema/commands/record.py
@@ -2,16 +2,15 @@ import os
 import sys
 import tempfile
 
-import asciinema.recorder as recorder
 import asciinema.asciicast.raw as raw
 import asciinema.asciicast.v2 as v2
 import asciinema.notifier as notifier
+import asciinema.recorder as recorder
 from asciinema.api import APIError
 from asciinema.commands.command import Command
 
 
 class RecordCommand(Command):
-
     def __init__(self, args, config, env):
         Command.__init__(self, args, config, env)
         self.quiet = args.quiet
@@ -26,11 +25,13 @@ class RecordCommand(Command):
         self.overwrite = args.overwrite
         self.raw = args.raw
         self.writer = raw.writer if args.raw else v2.writer
-        self.notifier = notifier.get_notifier(config.notifications_enabled, config.notifications_command)
+        self.notifier = notifier.get_notifier(
+            config.notifications_enabled, config.notifications_command
+        )
         self.env = env
         self.key_bindings = {
-            'prefix': config.record_prefix_key,
-            'pause': config.record_pause_key
+            "prefix": config.record_prefix_key,
+            "pause": config.record_pause_key,
         }
 
     def execute(self):
@@ -39,7 +40,9 @@ class RecordCommand(Command):
 
         if self.filename == "":
             if self.raw:
-                self.print_error("filename required when recording in raw mode")
+                self.print_error(
+                    "filename required when recording in raw mode"
+                )
                 return 1
             else:
                 self.filename = _tmp_path()
@@ -56,8 +59,12 @@ class RecordCommand(Command):
 
             elif os.stat(self.filename).st_size > 0 and not append:
                 self.print_error("%s already exists, aborting" % self.filename)
-                self.print_error("use --overwrite option if you want to overwrite existing recording")
-                self.print_error("use --append option if you want to append to existing recording")
+                self.print_error(
+                    "use --overwrite option if you want to overwrite existing recording"
+                )
+                self.print_error(
+                    "use --append option if you want to append to existing recording"
+                )
                 return 1
 
         if append:
@@ -68,9 +75,13 @@ class RecordCommand(Command):
         if self.command:
             self.print_info("""exit opened program when you're done""")
         else:
-            self.print_info("""press <ctrl-d> or type "exit" when you're done""")
+            self.print_info(
+                """press <ctrl-d> or type "exit" when you're done"""
+            )
 
-        vars = filter(None, map((lambda var: var.strip()), self.env_whitelist.split(',')))
+        vars = filter(
+            None, map((lambda var: var.strip()), self.env_whitelist.split(","))
+        )
 
         try:
             recorder.record(
@@ -84,18 +95,22 @@ class RecordCommand(Command):
                 rec_stdin=self.rec_stdin,
                 writer=self.writer,
                 notifier=self.notifier,
-                key_bindings=self.key_bindings
+                key_bindings=self.key_bindings,
             )
         except v2.LoadError:
-            self.print_error("can only append to asciicast v2 format recordings")
+            self.print_error(
+                "can only append to asciicast v2 format recordings"
+            )
             return 1
 
         self.print_info("recording finished")
 
         if upload:
             if not self.assume_yes:
-                self.print_info("press <enter> to upload to %s, <ctrl-c> to save locally"
-                                % self.api.hostname())
+                self.print_info(
+                    "press <enter> to upload to %s, <ctrl-c> to save locally"
+                    % self.api.hostname()
+                )
                 try:
                     sys.stdin.readline()
                 except KeyboardInterrupt:
@@ -110,12 +125,15 @@ class RecordCommand(Command):
                     self.print_warning(warn)
 
                 os.remove(self.filename)
-                self.print(result.get('message') or result['url'])
+                self.print(result.get("message") or result["url"])
 
             except APIError as e:
                 self.print("\r\x1b[A", end="")
                 self.print_error("upload failed: %s" % str(e))
-                self.print_error("retry later by running: asciinema upload %s" % self.filename)
+                self.print_error(
+                    "retry later by running: asciinema upload %s"
+                    % self.filename
+                )
                 return 1
         else:
             self.print_info("asciicast saved to %s" % self.filename)
@@ -124,6 +142,6 @@ class RecordCommand(Command):
 
 
 def _tmp_path():
-    fd, path = tempfile.mkstemp(suffix='-ascii.cast')
+    fd, path = tempfile.mkstemp(suffix="-ascii.cast")
     os.close(fd)
     return path

--- a/asciinema/commands/upload.py
+++ b/asciinema/commands/upload.py
@@ -1,9 +1,8 @@
-from asciinema.commands.command import Command
 from asciinema.api import APIError
+from asciinema.commands.command import Command
 
 
 class UploadCommand(Command):
-
     def __init__(self, args, config, env):
         Command.__init__(self, args, config, env)
         self.filename = args.filename
@@ -15,7 +14,7 @@ class UploadCommand(Command):
             if warn:
                 self.print_warning(warn)
 
-            self.print(result.get('message') or result['url'])
+            self.print(result.get("message") or result["url"])
 
         except OSError as e:
             self.print_error("upload failed: %s" % str(e))
@@ -23,7 +22,9 @@ class UploadCommand(Command):
 
         except APIError as e:
             self.print_error("upload failed: %s" % str(e))
-            self.print_error("retry later by running: asciinema upload %s" % self.filename)
+            self.print_error(
+                "retry later by running: asciinema upload %s" % self.filename
+            )
             return 1
 
         return 0

--- a/asciinema/commands/upload.py
+++ b/asciinema/commands/upload.py
@@ -1,13 +1,16 @@
-from asciinema.api import APIError
-from asciinema.commands.command import Command
+from typing import Any
+
+from ..api import APIError
+from ..config import Config
+from .command import Command
 
 
 class UploadCommand(Command):
-    def __init__(self, args, config, env):
+    def __init__(self, args: Any, config: Config, env: Any) -> None:
         Command.__init__(self, args, config, env)
         self.filename = args.filename
 
-    def execute(self):
+    def execute(self) -> int:
         try:
             result, warn = self.api.upload_asciicast(self.filename)
 

--- a/asciinema/commands/upload.py
+++ b/asciinema/commands/upload.py
@@ -17,13 +17,13 @@ class UploadCommand(Command):
             self.print(result.get("message") or result["url"])
 
         except OSError as e:
-            self.print_error("upload failed: %s" % str(e))
+            self.print_error(f"upload failed: {str(e)}")
             return 1
 
         except APIError as e:
-            self.print_error("upload failed: %s" % str(e))
+            self.print_error(f"upload failed: {str(e)}")
             self.print_error(
-                "retry later by running: asciinema upload %s" % self.filename
+                f"retry later by running: asciinema upload {self.filename}"
             )
             return 1
 

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -1,24 +1,22 @@
+import configparser
 import os
 import os.path as path
-import sys
 import uuid
-import configparser
 
 
 class ConfigError(Exception):
     pass
 
 
-DEFAULT_API_URL = 'https://asciinema.org'
-DEFAULT_RECORD_ENV = 'SHELL,TERM'
+DEFAULT_API_URL = "https://asciinema.org"
+DEFAULT_RECORD_ENV = "SHELL,TERM"
 
 
 class Config:
-
     def __init__(self, config_home, env=None):
         self.config_home = config_home
         self.config_file_path = path.join(config_home, "config")
-        self.install_id_path = path.join(self.config_home, 'install-id')
+        self.install_id_path = path.join(self.config_home, "install-id")
         self.config = configparser.ConfigParser()
         self.config.read(self.config_file_path)
         self.env = env if env is not None else os.environ
@@ -27,20 +25,31 @@ class Config:
         try:
             self.install_id
         except ConfigError:
-            id = self.__api_token() or self.__user_token() or self.__gen_install_id()
+            id = (
+                self.__api_token()
+                or self.__user_token()
+                or self.__gen_install_id()
+            )
             self.__save_install_id(id)
 
-            items = {name: dict(section) for (name, section) in self.config.items()}
-            if items == {'DEFAULT': {}, 'api': {'token': id}} or items == {'DEFAULT': {}, 'user': {'token': id}}:
+            items = {
+                name: dict(section) for (name, section) in self.config.items()
+            }
+            if items == {"DEFAULT": {}, "api": {"token": id}} or items == {
+                "DEFAULT": {},
+                "user": {"token": id},
+            }:
                 os.remove(self.config_file_path)
 
-        if self.env.get('ASCIINEMA_API_TOKEN'):
-            raise ConfigError('ASCIINEMA_API_TOKEN variable is no longer supported, please use ASCIINEMA_INSTALL_ID instead')
+        if self.env.get("ASCIINEMA_API_TOKEN"):
+            raise ConfigError(
+                "ASCIINEMA_API_TOKEN variable is no longer supported, please use ASCIINEMA_INSTALL_ID instead"
+            )
 
     def __read_install_id(self):
         p = self.install_id_path
         if path.isfile(p):
-            with open(p, 'r') as f:
+            with open(p, "r") as f:
                 return f.read().strip()
 
     def __gen_install_id(self):
@@ -49,7 +58,7 @@ class Config:
     def __save_install_id(self, id):
         self.__create_config_home()
 
-        with open(self.install_id_path, 'w') as f:
+        with open(self.install_id_path, "w") as f:
             f.write(id)
 
     def __create_config_home(self):
@@ -58,103 +67,117 @@ class Config:
 
     def __api_token(self):
         try:
-            return self.config.get('api', 'token')
+            return self.config.get("api", "token")
         except (configparser.NoOptionError, configparser.NoSectionError):
             pass
 
     def __user_token(self):
         try:
-            return self.config.get('user', 'token')
+            return self.config.get("user", "token")
         except (configparser.NoOptionError, configparser.NoSectionError):
             pass
 
     @property
     def install_id(self):
-        id = self.env.get('ASCIINEMA_INSTALL_ID') or self.__read_install_id()
+        id = self.env.get("ASCIINEMA_INSTALL_ID") or self.__read_install_id()
 
         if id:
             return id
         else:
-            raise ConfigError('no install ID found')
+            raise ConfigError("no install ID found")
 
     @property
     def api_url(self):
         return self.env.get(
-            'ASCIINEMA_API_URL',
-            self.config.get('api', 'url', fallback=DEFAULT_API_URL)
+            "ASCIINEMA_API_URL",
+            self.config.get("api", "url", fallback=DEFAULT_API_URL),
         )
 
     @property
     def record_stdin(self):
-        return self.config.getboolean('record', 'stdin', fallback=False)
+        return self.config.getboolean("record", "stdin", fallback=False)
 
     @property
     def record_command(self):
-        return self.config.get('record', 'command', fallback=None)
+        return self.config.get("record", "command", fallback=None)
 
     @property
     def record_env(self):
-        return self.config.get('record', 'env', fallback=DEFAULT_RECORD_ENV)
+        return self.config.get("record", "env", fallback=DEFAULT_RECORD_ENV)
 
     @property
     def record_idle_time_limit(self):
-        fallback = self.config.getfloat('record', 'maxwait', fallback=None)  # pre 2.0
-        return self.config.getfloat('record', 'idle_time_limit', fallback=fallback)
+        fallback = self.config.getfloat(
+            "record", "maxwait", fallback=None
+        )  # pre 2.0
+        return self.config.getfloat(
+            "record", "idle_time_limit", fallback=fallback
+        )
 
     @property
     def record_yes(self):
-        return self.config.getboolean('record', 'yes', fallback=False)
+        return self.config.getboolean("record", "yes", fallback=False)
 
     @property
     def record_quiet(self):
-        return self.config.getboolean('record', 'quiet', fallback=False)
+        return self.config.getboolean("record", "quiet", fallback=False)
 
     @property
     def record_prefix_key(self):
-        return self.__get_key('record', 'prefix')
+        return self.__get_key("record", "prefix")
 
     @property
     def record_pause_key(self):
-        return self.__get_key('record', 'pause', 'C-\\')
+        return self.__get_key("record", "pause", "C-\\")
 
     @property
     def play_idle_time_limit(self):
-        fallback = self.config.getfloat('play', 'maxwait', fallback=None)  # pre 2.0
-        return self.config.getfloat('play', 'idle_time_limit', fallback=fallback)
+        fallback = self.config.getfloat(
+            "play", "maxwait", fallback=None
+        )  # pre 2.0
+        return self.config.getfloat(
+            "play", "idle_time_limit", fallback=fallback
+        )
 
     @property
     def play_speed(self):
-        return self.config.getfloat('play', 'speed', fallback=1.0)
+        return self.config.getfloat("play", "speed", fallback=1.0)
 
     @property
     def play_pause_key(self):
-        return self.__get_key('play', 'pause', ' ')
+        return self.__get_key("play", "pause", " ")
 
     @property
     def play_step_key(self):
-        return self.__get_key('play', 'step', '.')
+        return self.__get_key("play", "step", ".")
 
     @property
     def notifications_enabled(self):
-        return self.config.getboolean('notifications', 'enabled', fallback=True)
+        return self.config.getboolean(
+            "notifications", "enabled", fallback=True
+        )
 
     @property
     def notifications_command(self):
-        return self.config.get('notifications', 'command', fallback=None)
+        return self.config.get("notifications", "command", fallback=None)
 
     def __get_key(self, section, name, default=None):
-        key = self.config.get(section, name + '_key', fallback=default)
+        key = self.config.get(section, name + "_key", fallback=default)
 
         if key:
             if len(key) == 3:
                 upper_key = key.upper()
 
-                if upper_key[0] == 'C' and upper_key[1] == '-':
+                if upper_key[0] == "C" and upper_key[1] == "-":
                     return bytes([ord(upper_key[2]) - 0x40])
                 else:
-                    raise ConfigError('invalid {name} key definition \'{key}\' - use: {name}_key = C-x (with control key modifier), or {name}_key = x (with no modifier)'.format(name=name, key=key))
+                    raise ConfigError(
+                        "invalid {name} key definition '{key}' - use: {name}_key = C-x (with control key modifier), or {name}_key = x (with no modifier)".format(
+                            name=name, key=key
+                        )
+                    )
             else:
-                return key.encode('utf-8')
+                return key.encode("utf-8")
 
 
 def get_config_home(env=os.environ):
@@ -175,7 +198,9 @@ def get_config_home(env=os.environ):
         else:
             config_home = path.join(env_home, ".config", "asciinema")
     else:
-        raise Exception("need $HOME or $XDG_CONFIG_HOME or $ASCIINEMA_CONFIG_HOME")
+        raise Exception(
+            "need $HOME or $XDG_CONFIG_HOME or $ASCIINEMA_CONFIG_HOME"
+        )
 
     return config_home
 

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -172,9 +172,9 @@ class Config:
                     return bytes([ord(upper_key[2]) - 0x40])
                 else:
                     raise ConfigError(
-                        "invalid {name} key definition '{key}' - use: {name}_key = C-x (with control key modifier), or {name}_key = x (with no modifier)".format(
-                            name=name, key=key
-                        )
+                        f"invalid {name} key definition '{key}' - use"
+                        f": {name}_key = C-x (with control key modifier)"
+                        f", or {name}_key = x (with no modifier)"
                     )
             else:
                 return key.encode("utf-8")

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -1,19 +1,23 @@
 import configparser
 import os
-import os.path as path
-import uuid
+from os import path
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+DEFAULT_API_URL: str = "https://asciinema.org"
+DEFAULT_RECORD_ENV: str = "SHELL,TERM"
 
 
 class ConfigError(Exception):
     pass
 
 
-DEFAULT_API_URL = "https://asciinema.org"
-DEFAULT_RECORD_ENV = "SHELL,TERM"
-
-
 class Config:
-    def __init__(self, config_home, env=None):
+    def __init__(
+        self,
+        config_home: Any,
+        env: Optional[Dict[str, str]] = None,
+    ) -> None:
         self.config_home = config_home
         self.config_file_path = path.join(config_home, "config")
         self.install_id_path = path.join(self.config_home, "install-id")
@@ -21,92 +25,94 @@ class Config:
         self.config.read(self.config_file_path)
         self.env = env if env is not None else os.environ
 
-    def upgrade(self):
+    def upgrade(self) -> None:
         try:
             self.install_id
         except ConfigError:
-            id = (
+            id_ = (
                 self.__api_token()
                 or self.__user_token()
                 or self.__gen_install_id()
             )
-            self.__save_install_id(id)
+            self.__save_install_id(id_)
 
             items = {
                 name: dict(section) for (name, section) in self.config.items()
             }
-            if items == {"DEFAULT": {}, "api": {"token": id}} or items == {
-                "DEFAULT": {},
-                "user": {"token": id},
-            }:
+            if items in (
+                {"DEFAULT": {}, "api": {"token": id_}},
+                {"DEFAULT": {}, "user": {"token": id_}},
+            ):
                 os.remove(self.config_file_path)
 
         if self.env.get("ASCIINEMA_API_TOKEN"):
             raise ConfigError(
-                "ASCIINEMA_API_TOKEN variable is no longer supported, please use ASCIINEMA_INSTALL_ID instead"
+                "ASCIINEMA_API_TOKEN variable is no longer supported"
+                ", please use ASCIINEMA_INSTALL_ID instead"
             )
 
-    def __read_install_id(self):
+    def __read_install_id(self) -> Optional[str]:
         p = self.install_id_path
         if path.isfile(p):
-            with open(p, "r") as f:
+            with open(p, "r", encoding="utf-8") as f:
                 return f.read().strip()
+        return None
 
-    def __gen_install_id(self):
-        return str(uuid.uuid4())
+    @staticmethod
+    def __gen_install_id() -> str:
+        return f"{uuid4()}"
 
-    def __save_install_id(self, id):
+    def __save_install_id(self, id_: str) -> None:
         self.__create_config_home()
 
-        with open(self.install_id_path, "w") as f:
-            f.write(id)
+        with open(self.install_id_path, "w", encoding="utf-8") as f:
+            f.write(id_)
 
-    def __create_config_home(self):
+    def __create_config_home(self) -> None:
         if not path.exists(self.config_home):
             os.makedirs(self.config_home)
 
-    def __api_token(self):
+    def __api_token(self) -> Optional[str]:
         try:
             return self.config.get("api", "token")
         except (configparser.NoOptionError, configparser.NoSectionError):
-            pass
+            return None
 
-    def __user_token(self):
+    def __user_token(self) -> Optional[str]:
         try:
             return self.config.get("user", "token")
         except (configparser.NoOptionError, configparser.NoSectionError):
-            pass
+            return None
 
     @property
-    def install_id(self):
-        id = self.env.get("ASCIINEMA_INSTALL_ID") or self.__read_install_id()
+    def install_id(self) -> str:
+        id_ = self.env.get("ASCIINEMA_INSTALL_ID") or self.__read_install_id()
 
-        if id:
-            return id
-        else:
-            raise ConfigError("no install ID found")
+        if id_:
+            return id_
+        raise ConfigError("no install ID found")
 
     @property
-    def api_url(self):
+    def api_url(self) -> str:
         return self.env.get(
             "ASCIINEMA_API_URL",
             self.config.get("api", "url", fallback=DEFAULT_API_URL),
         )
 
     @property
-    def record_stdin(self):
+    def record_stdin(self) -> bool:
         return self.config.getboolean("record", "stdin", fallback=False)
 
     @property
-    def record_command(self):
+    def record_command(self) -> Optional[str]:
         return self.config.get("record", "command", fallback=None)
 
     @property
-    def record_env(self):
+    def record_env(self) -> str:
         return self.config.get("record", "env", fallback=DEFAULT_RECORD_ENV)
 
     @property
-    def record_idle_time_limit(self):
+    def record_idle_time_limit(self) -> Optional[float]:
         fallback = self.config.getfloat(
             "record", "maxwait", fallback=None
         )  # pre 2.0
@@ -115,23 +121,23 @@ class Config:
         )
 
     @property
-    def record_yes(self):
+    def record_yes(self) -> bool:
         return self.config.getboolean("record", "yes", fallback=False)
 
     @property
-    def record_quiet(self):
+    def record_quiet(self) -> bool:
         return self.config.getboolean("record", "quiet", fallback=False)
 
     @property
-    def record_prefix_key(self):
+    def record_prefix_key(self) -> Any:
         return self.__get_key("record", "prefix")
 
     @property
-    def record_pause_key(self):
+    def record_pause_key(self) -> Any:
         return self.__get_key("record", "pause", "C-\\")
 
     @property
-    def play_idle_time_limit(self):
+    def play_idle_time_limit(self) -> Optional[float]:
         fallback = self.config.getfloat(
             "play", "maxwait", fallback=None
         )  # pre 2.0
@@ -140,28 +146,28 @@ class Config:
         )
 
     @property
-    def play_speed(self):
+    def play_speed(self) -> float:
         return self.config.getfloat("play", "speed", fallback=1.0)
 
     @property
-    def play_pause_key(self):
+    def play_pause_key(self) -> Any:
         return self.__get_key("play", "pause", " ")
 
     @property
-    def play_step_key(self):
+    def play_step_key(self) -> Any:
         return self.__get_key("play", "step", ".")
 
     @property
-    def notifications_enabled(self):
+    def notifications_enabled(self) -> bool:
         return self.config.getboolean(
             "notifications", "enabled", fallback=True
         )
 
     @property
-    def notifications_command(self):
+    def notifications_command(self) -> Optional[str]:
         return self.config.get("notifications", "command", fallback=None)
 
-    def __get_key(self, section, name, default=None):
+    def __get_key(self, section: str, name: str, default: Any = None) -> Any:
         key = self.config.get(section, name + "_key", fallback=default)
 
         if key:
@@ -170,22 +176,23 @@ class Config:
 
                 if upper_key[0] == "C" and upper_key[1] == "-":
                     return bytes([ord(upper_key[2]) - 0x40])
-                else:
-                    raise ConfigError(
-                        f"invalid {name} key definition '{key}' - use"
-                        f": {name}_key = C-x (with control key modifier)"
-                        f", or {name}_key = x (with no modifier)"
-                    )
-            else:
-                return key.encode("utf-8")
+                raise ConfigError(
+                    f"invalid {name} key definition '{key}' - use"
+                    f": {name}_key = C-x (with control key modifier)"
+                    f", or {name}_key = x (with no modifier)"
+                )
+            return key.encode("utf-8")
+        return None
 
 
-def get_config_home(env=os.environ):
+def get_config_home(env: Any = None) -> Any:
+    if env is None:
+        env = os.environ
     env_asciinema_config_home = env.get("ASCIINEMA_CONFIG_HOME")
     env_xdg_config_home = env.get("XDG_CONFIG_HOME")
     env_home = env.get("HOME")
 
-    config_home = None
+    config_home: Optional[str] = None
 
     if env_asciinema_config_home:
         config_home = env_asciinema_config_home
@@ -205,7 +212,9 @@ def get_config_home(env=os.environ):
     return config_home
 
 
-def load(env=os.environ):
+def load(env: Any = None) -> Config:
+    if env is None:
+        env = os.environ
     config = Config(get_config_home(env), env)
     config.upgrade()
     return config

--- a/asciinema/notifier.py
+++ b/asciinema/notifier.py
@@ -3,7 +3,7 @@ import shutil
 import subprocess
 
 
-class Notifier():
+class Notifier:
     def is_available(self):
         return shutil.which(self.cmd) is not None
 
@@ -13,7 +13,10 @@ class Notifier():
         # so we capture and ignore all output
 
     def get_icon_path(self):
-        path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data/icon-256x256.png")
+        path = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "data/icon-256x256.png",
+        )
 
         if os.path.exists(path):
             return path
@@ -24,7 +27,11 @@ class AppleScriptNotifier(Notifier):
 
     def args(self, text):
         text = text.replace('"', '\\"')
-        return ['osascript', '-e', 'display notification "{}" with title "asciinema"'.format(text)]
+        return [
+            "osascript",
+            "-e",
+            f'display notification "{text}" with title "asciinema"',
+        ]
 
 
 class LibNotifyNotifier(Notifier):
@@ -34,9 +41,9 @@ class LibNotifyNotifier(Notifier):
         icon_path = self.get_icon_path()
 
         if icon_path is not None:
-            return ['notify-send', '-i', icon_path, 'asciinema', text]
+            return ["notify-send", "-i", icon_path, "asciinema", text]
         else:
-            return ['notify-send', 'asciinema', text]
+            return ["notify-send", "asciinema", text]
 
 
 class TerminalNotifier(Notifier):
@@ -46,9 +53,23 @@ class TerminalNotifier(Notifier):
         icon_path = self.get_icon_path()
 
         if icon_path is not None:
-            return ['terminal-notifier', '-title', 'asciinema', '-message', text, '-appIcon', icon_path]
+            return [
+                "terminal-notifier",
+                "-title",
+                "asciinema",
+                "-message",
+                text,
+                "-appIcon",
+                icon_path,
+            ]
         else:
-            return ['terminal-notifier', '-title', 'asciinema', '-message', text]
+            return [
+                "terminal-notifier",
+                "-title",
+                "asciinema",
+                "-message",
+                text,
+            ]
 
 
 class CustomCommandNotifier(Notifier):
@@ -57,14 +78,14 @@ class CustomCommandNotifier(Notifier):
         self.command = command
 
     def notify(self, text):
-        args = ['/bin/sh', '-c', self.command]
+        args = ["/bin/sh", "-c", self.command]
         env = os.environ.copy()
-        env['TEXT'] = text
-        env['ICON_PATH'] = self.get_icon_path()
+        env["TEXT"] = text
+        env["ICON_PATH"] = self.get_icon_path()
         subprocess.run(args, env=env, capture_output=True)
 
 
-class NoopNotifier():
+class NoopNotifier:
     def notify(self, text):
         pass
 
@@ -74,7 +95,11 @@ def get_notifier(enabled=True, command=None):
         if command:
             return CustomCommandNotifier(command)
         else:
-            for c in [TerminalNotifier, AppleScriptNotifier, LibNotifyNotifier]:
+            for c in [
+                TerminalNotifier,
+                AppleScriptNotifier,
+                LibNotifyNotifier,
+            ]:
                 n = c()
 
                 if n.is_available():

--- a/asciinema/notifier.py
+++ b/asciinema/notifier.py
@@ -1,55 +1,68 @@
-import os.path
 import shutil
 import subprocess
+from os import environ, path
+from typing import Dict, List, Optional, Union
 
 
 class Notifier:
-    def is_available(self):
-        return shutil.which(self.cmd) is not None
+    def __init__(self, cmd: str) -> None:
+        self.cmd = cmd
 
-    def notify(self, text):
-        subprocess.run(self.args(text), capture_output=True)
-        # we don't want to print *ANYTHING* to the terminal
-        # so we capture and ignore all output
-
-    def get_icon_path(self):
-        path = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)),
+    @staticmethod
+    def get_icon_path() -> Optional[str]:
+        path_ = path.join(
+            path.dirname(path.realpath(__file__)),
             "data/icon-256x256.png",
         )
 
-        if os.path.exists(path):
-            return path
+        if path.exists(path_):
+            return path_
+        return None
+
+    def args(self, _text: str) -> List[str]:
+        return ["/bin/sh", "-c", self.cmd]
+
+    def is_available(self) -> bool:
+        return shutil.which(self.cmd) is not None
+
+    def notify(self, text: str) -> None:
+        # We do not want to raise a `CalledProcessError` on command failure.
+        # pylint: disable=subprocess-run-check
+        # We do not want to print *ANYTHING* to the terminal
+        # so we capture and ignore all output
+        subprocess.run(self.args(text), capture_output=True)
 
 
 class AppleScriptNotifier(Notifier):
-    cmd = "osascript"
+    def __init__(self) -> None:
+        super().__init__("osascript")
 
-    def args(self, text):
+    def args(self, text: str) -> List[str]:
         text = text.replace('"', '\\"')
         return [
-            "osascript",
+            self.cmd,
             "-e",
             f'display notification "{text}" with title "asciinema"',
         ]
 
 
 class LibNotifyNotifier(Notifier):
-    cmd = "notify-send"
+    def __init__(self) -> None:
+        super().__init__("notify-send")
 
-    def args(self, text):
+    def args(self, text: str) -> List[str]:
         icon_path = self.get_icon_path()
 
         if icon_path is not None:
-            return ["notify-send", "-i", icon_path, "asciinema", text]
-        else:
-            return ["notify-send", "asciinema", text]
+            return [self.cmd, "-i", icon_path, "asciinema", text]
+        return [self.cmd, "asciinema", text]
 
 
 class TerminalNotifier(Notifier):
-    cmd = "terminal-notifier"
+    def __init__(self) -> None:
+        super().__init__("terminal-notifier")
 
-    def args(self, text):
+    def args(self, text: str) -> List[str]:
         icon_path = self.get_icon_path()
 
         if icon_path is not None:
@@ -62,47 +75,47 @@ class TerminalNotifier(Notifier):
                 "-appIcon",
                 icon_path,
             ]
-        else:
-            return [
-                "terminal-notifier",
-                "-title",
-                "asciinema",
-                "-message",
-                text,
-            ]
+        return [
+            "terminal-notifier",
+            "-title",
+            "asciinema",
+            "-message",
+            text,
+        ]
 
 
 class CustomCommandNotifier(Notifier):
-    def __init__(self, command):
-        Notifier.__init__(self)
-        self.command = command
-
-    def notify(self, text):
-        args = ["/bin/sh", "-c", self.command]
-        env = os.environ.copy()
+    def env(self, text: str) -> Dict[str, str]:
+        icon_path = self.get_icon_path()
+        env = environ.copy()
         env["TEXT"] = text
-        env["ICON_PATH"] = self.get_icon_path()
-        subprocess.run(args, env=env, capture_output=True)
+        if icon_path is not None:
+            env["ICON_PATH"] = icon_path
+        return env
+
+    def notify(self, text: str) -> None:
+        # We do not want to raise a `CalledProcessError` on command failure.
+        # pylint: disable=subprocess-run-check
+        subprocess.run(
+            self.args(text), env=self.env(text), capture_output=True
+        )
 
 
-class NoopNotifier:
-    def notify(self, text):
+class NoopNotifier:  # pylint: disable=too-few-public-methods
+    def notify(self) -> None:
         pass
 
 
-def get_notifier(enabled=True, command=None):
+def get_notifier(
+    enabled: bool = True, command: Optional[str] = None
+) -> Union[Notifier, NoopNotifier]:
     if enabled:
         if command:
             return CustomCommandNotifier(command)
-        else:
-            for c in [
-                TerminalNotifier,
-                AppleScriptNotifier,
-                LibNotifyNotifier,
-            ]:
-                n = c()
+        for c in [TerminalNotifier, AppleScriptNotifier, LibNotifyNotifier]:
+            n = c()
 
-                if n.is_available():
-                    return n
+            if n.is_available():
+                return n
 
     return NoopNotifier()

--- a/asciinema/player.py
+++ b/asciinema/player.py
@@ -1,25 +1,43 @@
-import os
 import sys
 import time
+from typing import Any, Dict, Optional, TextIO, Union
 
-import asciinema.asciicast.events as ev
-from asciinema.term import raw, read_blocking
+from .asciicast import events as ev
+from .asciicast.v1 import Asciicast as v1
+from .asciicast.v2 import Asciicast as v2
+from .term import raw, read_blocking
 
 
-class Player:
-
-    def play(self, asciicast, idle_time_limit=None, speed=1.0, key_bindings={}):
+class Player:  # pylint: disable=too-few-public-methods
+    def play(
+        self,
+        asciicast: Union[v1, v2],
+        idle_time_limit: Optional[int] = None,
+        speed: float = 1.0,
+        key_bindings: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if key_bindings is None:
+            key_bindings = {}
         try:
-            stdin = open('/dev/tty')
-            with raw(stdin.fileno()):
-                self._play(asciicast, idle_time_limit, speed, stdin, key_bindings)
-        except Exception:
+            with open("/dev/tty", "rt", encoding="utf-8") as stdin:
+                with raw(stdin.fileno()):
+                    self._play(
+                        asciicast, idle_time_limit, speed, stdin, key_bindings
+                    )
+        except Exception:  # pylint: disable=broad-except
             self._play(asciicast, idle_time_limit, speed, None, key_bindings)
 
-    def _play(self, asciicast, idle_time_limit, speed, stdin, key_bindings):
+    @staticmethod
+    def _play(  # pylint: disable=too-many-locals
+        asciicast: Union[v1, v2],
+        idle_time_limit: Optional[int],
+        speed: float,
+        stdin: Optional[TextIO],
+        key_bindings: Dict[str, Any],
+    ) -> None:
         idle_time_limit = idle_time_limit or asciicast.idle_time_limit
-        pause_key = key_bindings.get('pause')
-        step_key = key_bindings.get('step')
+        pause_key = key_bindings.get("pause")
+        step_key = key_bindings.get("step")
 
         stdout = asciicast.stdout_events()
         stdout = ev.to_relative_time(stdout)
@@ -30,7 +48,7 @@ class Player:
         base_time = time.time()
         ctrl_c = False
         paused = False
-        pause_time = None
+        pause_time: Optional[float] = None
 
         for t, _type, text in stdout:
             delay = t - (time.time() - base_time)
@@ -46,7 +64,8 @@ class Player:
 
                         if data == pause_key:
                             paused = False
-                            base_time = base_time + (time.time() - pause_time)
+                            assert pause_time is not None
+                            base_time += time.time() - pause_time
                             break
 
                         if data == step_key:

--- a/asciinema/recorder.py
+++ b/asciinema/recorder.py
@@ -1,32 +1,37 @@
 import os
 import time
+from typing import Any, Callable, Dict, Optional, Tuple, Type
 
-from . import pty_ as pty  # avoid
+from . import pty_ as pty  # avoid collisions with standard library `pty`
 from . import term
 from .asciicast import v2
+from .asciicast.v2 import writer as w2
 from .async_worker import async_worker
 
 
-def record(
-    path,
-    command=None,
-    append=False,
-    idle_time_limit=None,
-    rec_stdin=False,
-    title=None,
-    metadata=None,
-    command_env=None,
-    capture_env=None,
-    writer=v2.writer,
-    record=pty.record,
-    notifier=None,
-    key_bindings={},
-):
+def record(  # pylint: disable=too-many-arguments,too-many-locals
+    path_: str,
+    command: Any = None,
+    append: bool = False,
+    idle_time_limit: Optional[int] = None,
+    rec_stdin: bool = False,
+    title: Optional[str] = None,
+    metadata: Any = None,
+    command_env: Optional[Dict[Any, Any]] = None,
+    capture_env: Any = None,
+    writer: Type[w2] = v2.writer,
+    record_: Callable[..., None] = pty.record,
+    notifier: Any = None,
+    key_bindings: Optional[Dict[str, Any]] = None,
+) -> None:
     if command is None:
-        command = os.environ.get("SHELL") or "sh"
+        command = os.environ.get("SHELL", "sh")
 
     if command_env is None:
         command_env = os.environ.copy()
+
+    if key_bindings is None:
+        key_bindings = {}
 
     command_env["ASCIINEMA_REC"] = "1"
 
@@ -35,7 +40,11 @@ def record(
 
     w, h = term.get_size()
 
-    full_metadata = {"width": w, "height": h, "timestamp": int(time.time())}
+    full_metadata: Dict[str, Any] = {
+        "width": w,
+        "height": h,
+        "timestamp": int(time.time()),
+    }
 
     full_metadata.update(metadata or {})
 
@@ -50,43 +59,48 @@ def record(
     if title:
         full_metadata["title"] = title
 
-    time_offset = 0
+    time_offset: float = 0
 
-    if append and os.stat(path).st_size > 0:
-        time_offset = v2.get_duration(path)
+    if append and os.stat(path_).st_size > 0:
+        assert time_offset is not None
+        time_offset = v2.get_duration(path_)
 
-    with async_writer(writer, path, full_metadata, append) as w:
-        with async_notifier(notifier) as n:
-            record(
+    with async_writer(writer, path_, full_metadata, append) as _writer:
+        with async_notifier(notifier) as _notifier:
+            record_(
                 ["sh", "-c", command],
-                w,
+                _writer,
                 command_env,
                 rec_stdin,
                 time_offset,
-                n,
+                _notifier,
                 key_bindings,
             )
 
 
 class async_writer(async_worker):
-    def __init__(self, writer, path, metadata, append=False):
+    def __init__(
+        self, writer: Type[w2], path_: str, metadata: Any, append: bool = False
+    ) -> None:
         async_worker.__init__(self)
         self.writer = writer
-        self.path = path
+        self.path = path_
         self.metadata = metadata
         self.append = append
 
-    def write_stdin(self, ts, data):
+    def write_stdin(self, ts: float, data: Any) -> None:
         self.enqueue([ts, "i", data])
 
-    def write_stdout(self, ts, data):
+    def write_stdout(self, ts: float, data: Any) -> None:
         self.enqueue([ts, "o", data])
 
-    def run(self):
+    def run(self) -> None:
         with self.writer(
             self.path, metadata=self.metadata, append=self.append
         ) as w:
+            event: Tuple[float, str, Any]
             for event in iter(self.queue.get, None):
+                assert event is not None
                 ts, etype, data = event
 
                 if etype == "o":
@@ -96,18 +110,18 @@ class async_writer(async_worker):
 
 
 class async_notifier(async_worker):
-    def __init__(self, notifier):
+    def __init__(self, notifier: Any) -> None:
         async_worker.__init__(self)
         self.notifier = notifier
 
-    def notify(self, text):
+    def notify(self, text: str) -> None:
         self.enqueue(text)
 
-    def perform(self, text):
+    def perform(self, text: str) -> None:
         try:
             if self.notifier:
                 self.notifier.notify(text)
-        except:
+        except:  # pylint: disable=bare-except # noqa: E722
             # we catch *ALL* exceptions here because we don't want failed
             # notification to crash the recording session
             pass

--- a/asciinema/term.py
+++ b/asciinema/term.py
@@ -1,42 +1,45 @@
 import os
 import select
 import subprocess
-import time
-import tty
+import termios as tty  # avoid `Module "tty" has no attribute ...` errors
+from time import sleep
+from tty import setraw
+from typing import IO, Any, List, Optional, Tuple, Union
 
 
-class raw():
-    def __init__(self, fd):
+class raw:
+    def __init__(self, fd: Union[IO[str], int]) -> None:
         self.fd = fd
-        self.restore = False
+        self.restore: bool = False
+        self.mode: Optional[List[Any]] = None
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         try:
             self.mode = tty.tcgetattr(self.fd)
-            tty.setraw(self.fd)
+            setraw(self.fd)
             self.restore = True
-        except tty.error:  # This is the same as termios.error
+        except tty.error:  # this is `termios.error`
             pass
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type_: str, value: str, traceback: str) -> None:
         if self.restore:
-            # Give the terminal time to send answerbacks
-            time.sleep(0.01)
+            sleep(0.01)  # give the terminal time to send answerbacks
+            assert isinstance(self.mode, list)
             tty.tcsetattr(self.fd, tty.TCSAFLUSH, self.mode)
 
 
-def read_blocking(fd, timeout):
+def read_blocking(fd: int, timeout: Any) -> bytes:
     if fd in select.select([fd], [], [], timeout)[0]:
         return os.read(fd, 1024)
 
-    return b''
+    return b""
 
 
-def get_size():
+def get_size() -> Tuple[int, int]:
     try:
         return os.get_terminal_size()
-    except:
+    except:  # pylint: disable=bare-except  # noqa: E722
         return (
-            int(subprocess.check_output(['tput', 'cols'])),
-            int(subprocess.check_output(['tput', 'lines']))
+            int(subprocess.check_output(["tput", "cols"])),
+            int(subprocess.check_output(["tput", "lines"])),
         )

--- a/asciinema/urllib_http_adapter.py
+++ b/asciinema/urllib_http_adapter.py
@@ -3,39 +3,44 @@ import codecs
 import http
 import io
 import sys
-import uuid
+from http.client import HTTPResponse
+from typing import Any, Dict, Generator, Optional, Tuple
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
+from uuid import uuid4
 
 from .http_adapter import HTTPConnectionError
 
 
 class MultipartFormdataEncoder:
-    def __init__(self):
-        self.boundary = uuid.uuid4().hex
+    def __init__(self) -> None:
+        self.boundary = uuid4().hex
         self.content_type = f"multipart/form-data; boundary={self.boundary}"
 
     @classmethod
-    def u(cls, s):
+    def u(cls, s: Any) -> Any:
         if sys.hexversion >= 0x03000000 and isinstance(s, bytes):
             s = s.decode("utf-8")
         return s
 
-    def iter(self, fields, files):
+    def iter(
+        self, fields: Dict[str, Any], files: Dict[str, Tuple[str, Any]]
+    ) -> Generator[Tuple[bytes, int], None, None]:
         """
-        fields is a dict of {name: value} for regular form fields.
-        files is a dict of {name: (filename, file-type)} for data to be uploaded as files
-        Yield body's chunk as bytes
+        fields: {name: value} for regular form fields.
+        files: {name: (filename, file-type)} for data to be uploaded as files
+
+        yield body's chunk as bytes
         """
         encoder = codecs.getencoder("utf-8")
         for (key, value) in fields.items():
             key = self.u(key)
             yield encoder(f"--{self.boundary}\r\n")
             yield encoder(
-                self.u(f'Content-Disposition: form-data; name="{key}"\r\n')
+                self.u(f'content-disposition: form-data; name="{key}"\r\n')
             )
             yield encoder("\r\n")
-            if isinstance(value, int) or isinstance(value, float):
+            if isinstance(value, (int, float)):
                 value = str(value)
             yield encoder(self.u(value))
             yield encoder("\r\n")
@@ -46,62 +51,73 @@ class MultipartFormdataEncoder:
             yield encoder(f"--{self.boundary}\r\n")
             yield encoder(
                 self.u(
-                    f'Content-Disposition: form-data; name="{key}"; filename="{filename}"\r\n'
+                    "content-disposition: form-data"
+                    f'; name="{key}"'
+                    f'; filename="{filename}"\r\n'
                 )
             )
-            yield encoder("Content-Type: application/octet-stream\r\n")
+            yield encoder("content-type: application/octet-stream\r\n")
             yield encoder("\r\n")
             data = f.read()
             yield (data, len(data))
             yield encoder("\r\n")
         yield encoder(f"--{self.boundary}--\r\n")
 
-    def encode(self, fields, files):
+    def encode(
+        self, fields: Dict[str, Any], files: Dict[str, Tuple[str, Any]]
+    ) -> Tuple[str, bytes]:
         body = io.BytesIO()
-        for chunk, chunk_len in self.iter(fields, files):
+        for chunk, _ in self.iter(fields, files):
             body.write(chunk)
         return self.content_type, body.getvalue()
 
 
-class URLLibHttpAdapter:
-    def post(
+class URLLibHttpAdapter:  # pylint: disable=too-few-public-methods
+    def post(  # pylint: disable=too-many-arguments,too-many-locals
         self,
-        url,
-        fields={},
-        files={},
-        headers={},
-        username=None,
-        password=None,
-    ):
+        url: str,
+        fields: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Tuple[str, Any]]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+    ) -> Tuple[Any, Optional[Dict[str, str]], bytes]:
+        # avoid dangerous mutable default arguments
+        if fields is None:
+            fields = {}
+        if files is None:
+            files = {}
+        if headers is None:
+            headers = {}
+
         content_type, body = MultipartFormdataEncoder().encode(fields, files)
 
         headers = headers.copy()
-        headers["Content-Type"] = content_type
+        headers["content-type"] = content_type
 
         if password:
             auth = f"{username}:{password}"
             encoded_auth = base64.b64encode(bytes(auth, "utf-8"))
-            headers["Authorization"] = b"Basic " + encoded_auth
+            headers["authorization"] = f"Basic {encoded_auth!r}"
 
         request = Request(url, data=body, headers=headers, method="POST")
 
         try:
-            response = urlopen(request)
-            status = response.status
-            headers = self._parse_headers(response)
-            body = response.read().decode("utf-8")
+            with urlopen(request) as response:
+                status = response.status
+                headers = self._parse_headers(response)
+                body = response.read().decode("utf-8")
         except HTTPError as e:
             status = e.code
             headers = {}
-            body = e.read().decode("utf-8")
+            body = e.read()
         except (http.client.RemoteDisconnected, URLError) as e:
-            raise HTTPConnectionError(str(e))
+            raise HTTPConnectionError(str(e)) from e
 
         return (status, headers, body)
 
-    def _parse_headers(self, response):
-        headers = {}
-        for k, v in response.getheaders():
-            headers[k.lower()] = v
+    @staticmethod
+    def _parse_headers(response: HTTPResponse) -> Dict[str, str]:
+        headers = {k.lower(): v for k, v in response.getheaders()}
 
         return headers

--- a/asciinema/urllib_http_adapter.py
+++ b/asciinema/urllib_http_adapter.py
@@ -13,9 +13,7 @@ from .http_adapter import HTTPConnectionError
 class MultipartFormdataEncoder:
     def __init__(self):
         self.boundary = uuid.uuid4().hex
-        self.content_type = "multipart/form-data; boundary={}".format(
-            self.boundary
-        )
+        self.content_type = f"multipart/form-data; boundary={self.boundary}"
 
     @classmethod
     def u(cls, s):
@@ -32,11 +30,9 @@ class MultipartFormdataEncoder:
         encoder = codecs.getencoder("utf-8")
         for (key, value) in fields.items():
             key = self.u(key)
-            yield encoder("--{}\r\n".format(self.boundary))
+            yield encoder(f"--{self.boundary}\r\n")
             yield encoder(
-                self.u('Content-Disposition: form-data; name="{}"\r\n').format(
-                    key
-                )
+                self.u(f'Content-Disposition: form-data; name="{key}"\r\n')
             )
             yield encoder("\r\n")
             if isinstance(value, int) or isinstance(value, float):
@@ -47,18 +43,18 @@ class MultipartFormdataEncoder:
             filename, f = filename_and_f
             key = self.u(key)
             filename = self.u(filename)
-            yield encoder("--{}\r\n".format(self.boundary))
+            yield encoder(f"--{self.boundary}\r\n")
             yield encoder(
                 self.u(
-                    'Content-Disposition: form-data; name="{}"; filename="{}"\r\n'
-                ).format(key, filename)
+                    f'Content-Disposition: form-data; name="{key}"; filename="{filename}"\r\n'
+                )
             )
             yield encoder("Content-Type: application/octet-stream\r\n")
             yield encoder("\r\n")
             data = f.read()
             yield (data, len(data))
             yield encoder("\r\n")
-        yield encoder("--{}--\r\n".format(self.boundary))
+        yield encoder(f"--{self.boundary}--\r\n")
 
     def encode(self, fields, files):
         body = io.BytesIO()
@@ -83,7 +79,7 @@ class URLLibHttpAdapter:
         headers["Content-Type"] = content_type
 
         if password:
-            auth = "%s:%s" % (username, password)
+            auth = f"{username}:{password}"
             encoded_auth = base64.b64encode(bytes(auth, "utf-8"))
             headers["Authorization"] = b"Basic " + encoded_auth
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,59 @@
 [metadata]
+name = asciinema
+version = 2.2.0
+author = Marcin Kulik
+author_email = m@ku1ik.com
+url = https://asciinema.org
+download_url =
+    https://github.com/asciinema/asciinema/archive/v%(version)s.tar.gz
+description = Terminal session recorder
 description_file = README.md
+license = GNU GPLv3
 license_file = LICENSE
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
+    Natural Language :: English
+    Programming Language :: Python
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Topic :: System :: Shells
+    Topic :: Terminals
+    Topic :: Utilities'
+
+[options]
+include_package_data = True
+packages =
+    asciinema
+    asciinema.asciicast
+    asciinema.commands
+install_requires =
+
+[options.package_data]
+asciinema = data/*.png
+
+[options.entry_points]
+console_scripts =
+    asciinema = asciinema.__main__:main
+
+[options.data_files]
+share/doc/asciinema =
+    CHANGELOG.md
+    CODE_OF_CONDUCT.md
+    CONTRIBUTING.md
+    README.md
+    doc/asciicast-v1.md
+    doc/asciicast-v2.md
+share/man/man1 =
+    man/asciinema.1
 
 [pycodestyle]
 ignore = E501,E402,E722

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -9,18 +9,20 @@ import asciinema.config as cfg
 
 
 def create_config(content=None, env={}):
-    dir = tempfile.mkdtemp()
+    # avoid redefining `dir` builtin
+    dir_ = tempfile.mkdtemp()
 
     if content:
-        path = dir + '/config'
-        with open(path, 'w') as f:
+        # avoid redefining `os.path`
+        path_ = f"{dir_}/config"
+        with open(path_, "wt", encoding="utf_8") as f:
             f.write(content)
 
-    return cfg.Config(dir, env)
+    return cfg.Config(dir_, env)
 
 
 def read_install_id(install_id_path):
-    with open(install_id_path, 'r') as f:
+    with open(install_id_path, "rt", encoding="utf_8") as f:
         return f.read().strip()
 
 
@@ -29,180 +31,187 @@ def test_upgrade_no_config_file():
     config.upgrade()
     install_id = read_install_id(config.install_id_path)
 
-    assert re.match('^\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}', install_id)
-    assert_equal(install_id, config.install_id)
+    assert re.match("^\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}", install_id)
+    assert install_id == config.install_id
     assert not path.exists(config.config_file_path)
 
     # it must not change after another upgrade
 
     config.upgrade()
 
-    assert_equal(read_install_id(config.install_id_path), install_id)
+    assert read_install_id(config.install_id_path) == install_id
 
 
 def test_upgrade_config_file_with_api_token():
     config = create_config("[api]\ntoken = foo-bar-baz")
     config.upgrade()
 
-    assert_equal(read_install_id(config.install_id_path), 'foo-bar-baz')
-    assert_equal(config.install_id, 'foo-bar-baz')
+    assert read_install_id(config.install_id_path) == "foo-bar-baz"
+    assert config.install_id == "foo-bar-baz"
     assert not path.exists(config.config_file_path)
 
     config.upgrade()
 
-    assert_equal(read_install_id(config.install_id_path), 'foo-bar-baz')
+    assert read_install_id(config.install_id_path) == "foo-bar-baz"
 
 
 def test_upgrade_config_file_with_api_token_and_more():
-    config = create_config("[api]\ntoken = foo-bar-baz\nurl = http://example.com")
+    config = create_config(
+        "[api]\ntoken = foo-bar-baz\nurl = http://example.com"
+    )
     config.upgrade()
 
-    assert_equal(read_install_id(config.install_id_path), 'foo-bar-baz')
-    assert_equal(config.install_id, 'foo-bar-baz')
-    assert_equal(config.api_url, 'http://example.com')
+    assert read_install_id(config.install_id_path) == "foo-bar-baz"
+    assert config.install_id == "foo-bar-baz"
+    assert config.api_url == "http://example.com"
     assert path.exists(config.config_file_path)
 
     config.upgrade()
 
-    assert_equal(read_install_id(config.install_id_path), 'foo-bar-baz')
+    assert read_install_id(config.install_id_path) == "foo-bar-baz"
 
 
 def test_upgrade_config_file_with_user_token():
     config = create_config("[user]\ntoken = foo-bar-baz")
     config.upgrade()
 
-    assert_equal(read_install_id(config.install_id_path), 'foo-bar-baz')
-    assert_equal(config.install_id, 'foo-bar-baz')
+    assert read_install_id(config.install_id_path) == "foo-bar-baz"
+    assert config.install_id == "foo-bar-baz"
     assert not path.exists(config.config_file_path)
 
     config.upgrade()
 
-    assert_equal(read_install_id(config.install_id_path), 'foo-bar-baz')
+    assert read_install_id(config.install_id_path) == "foo-bar-baz"
 
 
 def test_upgrade_config_file_with_user_token_and_more():
-    config = create_config("[user]\ntoken = foo-bar-baz\n[api]\nurl = http://example.com")
+    config = create_config(
+        "[user]\ntoken = foo-bar-baz\n[api]\nurl = http://example.com"
+    )
     config.upgrade()
 
-    assert_equal(read_install_id(config.install_id_path), 'foo-bar-baz')
-    assert_equal(config.install_id, 'foo-bar-baz')
-    assert_equal(config.api_url, 'http://example.com')
+    assert read_install_id(config.install_id_path) == "foo-bar-baz"
+    assert config.install_id == "foo-bar-baz"
+    assert config.api_url == "http://example.com"
     assert path.exists(config.config_file_path)
 
     config.upgrade()
 
-    assert_equal(read_install_id(config.install_id_path), 'foo-bar-baz')
+    assert read_install_id(config.install_id_path) == "foo-bar-baz"
 
 
 def test_default_api_url():
-    config = create_config('')
-    assert_equal('https://asciinema.org', config.api_url)
+    config = create_config("")
+    assert config.api_url == "https://asciinema.org"
 
 
 def test_default_record_stdin():
-    config = create_config('')
-    assert_equal(False, config.record_stdin)
+    config = create_config("")
+    assert config.record_stdin is False
 
 
 def test_default_record_command():
-    config = create_config('')
-    assert_equal(None, config.record_command)
+    config = create_config("")
+    assert config.record_command is None
 
 
 def test_default_record_env():
-    config = create_config('')
-    assert_equal('SHELL,TERM', config.record_env)
+    config = create_config("")
+    assert config.record_env == "SHELL,TERM"
 
 
 def test_default_record_idle_time_limit():
-    config = create_config('')
-    assert_equal(None, config.record_idle_time_limit)
+    config = create_config("")
+    assert config.record_idle_time_limit is None
 
 
 def test_default_record_yes():
-    config = create_config('')
-    assert_equal(False, config.record_yes)
+    config = create_config("")
+    assert config.record_yes is False
 
 
 def test_default_record_quiet():
-    config = create_config('')
-    assert_equal(False, config.record_quiet)
+    config = create_config("")
+    assert config.record_quiet is False
 
 
 def test_default_play_idle_time_limit():
-    config = create_config('')
-    assert_equal(None, config.play_idle_time_limit)
+    config = create_config("")
+    assert config.play_idle_time_limit is None
 
 
 def test_api_url():
     config = create_config("[api]\nurl = http://the/url")
-    assert_equal('http://the/url', config.api_url)
+    assert config.api_url == "http://the/url"
 
 
 def test_api_url_when_override_set():
-    config = create_config("[api]\nurl = http://the/url", {
-        'ASCIINEMA_API_URL': 'http://the/url2'})
-    assert_equal('http://the/url2', config.api_url)
+    config = create_config(
+        "[api]\nurl = http://the/url", {"ASCIINEMA_API_URL": "http://the/url2"}
+    )
+    assert config.api_url == "http://the/url2"
 
 
 def test_record_command():
-    command = 'bash -l'
+    command = "bash -l"
     config = create_config("[record]\ncommand = %s" % command)
-    assert_equal(command, config.record_command)
+    assert config.record_command == command
 
 
 def test_record_stdin():
     config = create_config("[record]\nstdin = yes")
-    assert_equal(True, config.record_stdin)
+    assert config.record_stdin is True
 
 
 def test_record_env():
     config = create_config("[record]\nenv = FOO,BAR")
-    assert_equal('FOO,BAR', config.record_env)
+    assert config.record_env == "FOO,BAR"
 
 
 def test_record_idle_time_limit():
     config = create_config("[record]\nidle_time_limit = 2.35")
-    assert_equal(2.35, config.record_idle_time_limit)
+    assert config.record_idle_time_limit == 2.35
 
     config = create_config("[record]\nmaxwait = 2.35")
-    assert_equal(2.35, config.record_idle_time_limit)
+    assert config.record_idle_time_limit == 2.35
 
 
 def test_record_yes():
-    yes = 'yes'
+    yes = "yes"
     config = create_config("[record]\nyes = %s" % yes)
-    assert_equal(True, config.record_yes)
+    assert config.record_yes is True
 
 
 def test_record_quiet():
-    quiet = 'yes'
+    quiet = "yes"
     config = create_config("[record]\nquiet = %s" % quiet)
-    assert_equal(True, config.record_quiet)
+    assert config.record_quiet is True
 
 
 def test_play_idle_time_limit():
     config = create_config("[play]\nidle_time_limit = 2.35")
-    assert_equal(2.35, config.play_idle_time_limit)
+    assert config.play_idle_time_limit == 2.35
 
     config = create_config("[play]\nmaxwait = 2.35")
-    assert_equal(2.35, config.play_idle_time_limit)
+    assert config.play_idle_time_limit == 2.35
 
 
 def test_notifications_enabled():
-    config = create_config('')
-    assert_equal(True, config.notifications_enabled)
+    config = create_config("")
+    assert config.notifications_enabled is True
 
     config = create_config("[notifications]\nenabled = yes")
-    assert_equal(True, config.notifications_enabled)
+    assert config.notifications_enabled is True
 
     config = create_config("[notifications]\nenabled = no")
-    assert_equal(False, config.notifications_enabled)
+    assert config.notifications_enabled is False
 
 
 def test_notifications_command():
-    config = create_config('')
-    assert_equal(None, config.notifications_command)
+    config = create_config("")
+    assert config.notifications_command is None
 
-    config = create_config('[notifications]\ncommand = tmux display-message "$TEXT"')
-    assert_equal('tmux display-message "$TEXT"', config.notifications_command)
+    config = create_config(
+        '[notifications]\ncommand = tmux display-message "$TEXT"'
+    )
+    assert config.notifications_command == 'tmux display-message "$TEXT"'

--- a/tests/distros/Dockerfile.alpine
+++ b/tests/distros/Dockerfile.alpine
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.3
 
-FROM docker.io/library/centos:7
+FROM docker.io/library/alpine:3.14
 
-RUN yum install -y epel-release && yum install -y python36 && yum clean all
+RUN apk --no-cache add bash ca-certificates python3
 
 WORKDIR /usr/src/app
 

--- a/tests/distros/Dockerfile.alpine
+++ b/tests/distros/Dockerfile.alpine
@@ -2,7 +2,8 @@
 
 FROM docker.io/library/alpine:3.14
 
-RUN apk --no-cache add bash ca-certificates python3
+# https://github.com/actions/runner/issues/241
+RUN apk --no-cache add bash ca-certificates make python3 util-linux
 
 WORKDIR /usr/src/app
 

--- a/tests/distros/Dockerfile.arch
+++ b/tests/distros/Dockerfile.arch
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.3
+
+FROM docker.io/library/archlinux:latest
+
+RUN pacman-key --init \
+    && pacman --sync --refresh --sysupgrade --noconfirm python3 \
+    && printf "LANG=en_US.UTF-8\n" > /etc/locale.conf \
+    && locale-gen \
+    && pacman --sync --clean --clean --noconfirm
+
+WORKDIR /usr/src/app
+
+COPY asciinema/ asciinema/
+COPY tests/ tests/
+
+ENV LANG="en_US.utf8"
+
+USER nobody
+
+ENTRYPOINT ["/bin/bash"]
+
+# vim:ft=dockerfile

--- a/tests/distros/Dockerfile.arch
+++ b/tests/distros/Dockerfile.arch
@@ -3,7 +3,7 @@
 FROM docker.io/library/archlinux:latest
 
 RUN pacman-key --init \
-    && pacman --sync --refresh --sysupgrade --noconfirm python3 \
+    && pacman --sync --refresh --sysupgrade --noconfirm make python3 \
     && printf "LANG=en_US.UTF-8\n" > /etc/locale.conf \
     && locale-gen \
     && pacman --sync --clean --clean --noconfirm

--- a/tests/distros/Dockerfile.centos
+++ b/tests/distros/Dockerfile.centos
@@ -2,7 +2,7 @@
 
 FROM docker.io/library/centos:7
 
-RUN yum install -y epel-release && yum install -y python36 && yum clean all
+RUN yum install -y epel-release && yum install -y make python36 && yum clean all
 
 WORKDIR /usr/src/app
 

--- a/tests/distros/Dockerfile.debian
+++ b/tests/distros/Dockerfile.debian
@@ -8,6 +8,7 @@ RUN apt-get update \
     && apt-get install -y \
         ca-certificates \
         locales \
+        make \
         procps \
         python3 \
     && localedef \

--- a/tests/distros/Dockerfile.debian
+++ b/tests/distros/Dockerfile.debian
@@ -1,13 +1,32 @@
-FROM debian:jessie
+# syntax=docker/dockerfile:1.3
 
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    locales \
-    python3
-RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+FROM docker.io/library/debian:bullseye
+
+ENV DEBIAN_FRONTENT="noninteractive"
+
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        locales \
+        procps \
+        python3 \
+    && localedef \
+        -i en_US \
+        -c \
+        -f UTF-8 \
+        -A /usr/share/locale/locale.alias \
+        en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /usr/src/app
-COPY asciinema asciinema
-COPY tests tests
-ENV LANG en_US.utf8
-ENV SHELL /bin/bash
-ENV USER docker
+
+COPY asciinema/ asciinema/
+COPY tests/ tests/
+
+ENV LANG="en_US.utf8"
+
+USER nobody
+
+ENV SHELL="/bin/bash"
+
+# vim:ft=dockerfile

--- a/tests/distros/Dockerfile.fedora
+++ b/tests/distros/Dockerfile.fedora
@@ -1,9 +1,20 @@
-FROM fedora:26
+# syntax=docker/dockerfile:1.3
 
-RUN dnf install -y python3 procps
+# https://medium.com/nttlabs/ubuntu-21-10-and-fedora-35-do-not-work-on-docker-20-10-9-1cd439d9921
+# https://www.mail-archive.com/ubuntu-bugs@lists.ubuntu.com/msg5971024.html
+FROM registry.fedoraproject.org/fedora:34
+
+RUN dnf install -y python3 procps && dnf clean all
+
 WORKDIR /usr/src/app
-COPY asciinema asciinema
-COPY tests tests
-ENV LANG en_US.utf8
-ENV SHELL /bin/bash
-ENV USER docker
+
+COPY asciinema/ asciinema/
+COPY tests/ tests/
+
+ENV LANG="en_US.utf8"
+ENV SHELL="/bin/bash"
+
+USER nobody
+
+ENTRYPOINT ["/bin/bash"]
+# vim:ft=dockerfile

--- a/tests/distros/Dockerfile.fedora
+++ b/tests/distros/Dockerfile.fedora
@@ -4,7 +4,7 @@
 # https://www.mail-archive.com/ubuntu-bugs@lists.ubuntu.com/msg5971024.html
 FROM registry.fedoraproject.org/fedora:34
 
-RUN dnf install -y python3 procps && dnf clean all
+RUN dnf install -y make python3 procps && dnf clean all
 
 WORKDIR /usr/src/app
 

--- a/tests/distros/Dockerfile.ubuntu
+++ b/tests/distros/Dockerfile.ubuntu
@@ -8,6 +8,7 @@ RUN apt-get update \
     && apt-get install -y \
         ca-certificates \
         locales \
+        make \
         python3 \
     && localedef \
         -i en_US \

--- a/tests/distros/Dockerfile.ubuntu
+++ b/tests/distros/Dockerfile.ubuntu
@@ -1,13 +1,31 @@
-FROM ubuntu:16.04
+# syntax=docker/dockerfile:1.3
 
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    locales \
-    python3
-RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+FROM docker.io/library/ubuntu:20.04
+
+ENV DEBIAN_FRONTENT="noninteractive"
+
+RUN apt-get update \
+    && apt-get install -y \
+        ca-certificates \
+        locales \
+        python3 \
+    && localedef \
+        -i en_US \
+        -c \
+        -f UTF-8 \
+        -A /usr/share/locale/locale.alias \
+        en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /usr/src/app
-COPY asciinema asciinema
-COPY tests tests
-ENV LANG en_US.utf8
-ENV SHELL /bin/bash
-ENV USER docker
+
+COPY asciinema/ asciinema/
+COPY tests/ tests/
+
+ENV LANG="en_US.utf8"
+
+USER nobody
+
+ENTRYPOINT ["/bin/bash"]
+
+# vim:ft=dockerfile

--- a/tests/pty_test.py
+++ b/tests/pty_test.py
@@ -1,7 +1,7 @@
 import os
 import pty
 
-import asciinema.pty
+import asciinema.pty_
 
 from .test_helper import Test
 
@@ -44,6 +44,6 @@ class TestRecord(Test):
                 "; sys.stdout.write('bar')"
             ),
         ]
-        asciinema.pty.record(command, output)
+        asciinema.pty_.record(command, output)
 
         assert output.data == [b"foo", b"bar"]

--- a/tests/pty_test.py
+++ b/tests/pty_test.py
@@ -1,14 +1,12 @@
 import os
 import pty
 
-from nose.tools import assert_equal
-from .test_helper import Test
-
 import asciinema.pty
+
+from .test_helper import Test
 
 
 class FakeStdout:
-
     def __init__(self):
         self.data = []
 
@@ -20,7 +18,6 @@ class FakeStdout:
 
 
 class TestRecord(Test):
-
     def setUp(self):
         self.real_os_write = os.write
         os.write = self.os_write
@@ -35,7 +32,18 @@ class TestRecord(Test):
     def test_record_command_writes_to_stdout(self):
         output = FakeStdout()
 
-        command = ['python3', '-c', "import sys; import time; sys.stdout.write(\'foo\'); sys.stdout.flush(); time.sleep(0.01); sys.stdout.write(\'bar\')"]
+        command = [
+            "python3",
+            "-c",
+            (
+                "import sys"
+                "; import time"
+                "; sys.stdout.write('foo')"
+                "; sys.stdout.flush()"
+                "; time.sleep(0.01)"
+                "; sys.stdout.write('bar')"
+            ),
+        ]
         asciinema.pty.record(command, output)
 
-        assert_equal([b'foo', b'bar'], output.data)
+        assert output.data == [b"foo", b"bar"]


### PR DESCRIPTION
- [style] Format package code
- [ci] Format asciinema workflow; add Python 3.10
- [container] Update Dockerfile for PEP 518 build
- [ci] Run container integration tests to CI
- [style] Ignore line break before binary operator
- [style] Replace calls to format() with f-strings
- Rename asciinema/pty.py => pty_.py
- [typing] Annotate asciinema.asciicast
- [typing] Annotate asciinema.async_worker
- [build] Refactor Makefile
- [build] Add clean, clean.all targets to Makefile
- [build] Run build target in VIRTUAL_ENV
- [build] Remove .mypy_cache with clean.all Makefile target
- [test] Convert unittests runner nose => pytest
- [test] Update test for asciinema.pty_
- [typing] Annotate ascinnema.urllib_http_adapter
- [typing] Annotate asciinema.api
- [typing] Annotate asciinema.config
- [typing] Annotate asciinema.term
- [typing] Annotate asciinema.pty_
- [typing] Annotate asciinema.__main__
- [typing] Annotate asciinema.player
- [typing] Annotate asciinema.recorder
- Refactor asciinema.notifier
- [typing] Annotate asciinema.commands.auth
- [typing] Annotate asciinema.commands.upload
- [typing] Annotate asciinema.commands.record
- [typing] Annotate asciinema.__init__
- [typing] Annotate asciinema.commands.cat
- [typing] Annotate asciinema.commands.command
- [typing] Annotate asciinema.commands.play
- [typing] Add asciinema/py.typed
- Support Python 3.6; remove annotations from __future__
- v2.2.0: Require Python 3.6+
- Normalize user-agent header casing in asciinema.api
- [doc] Update README
