### PR TITLE
Revert "[tests:distros] Update Fedora 34 => 35"

### DIFF
--- a/tests/distros/Dockerfile.fedora
+++ b/tests/distros/Dockerfile.fedora
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1.3
 
-FROM registry.fedoraproject.org/fedora:35
+# https://medium.com/nttlabs/ubuntu-21-10-and-fedora-35-do-not-work-on-docker-20-10-9-1cd439d9921
+# https://www.mail-archive.com/ubuntu-bugs@lists.ubuntu.com/msg5971024.html
+FROM registry.fedoraproject.org/fedora:34
 
 RUN dnf install -y make python3 procps && dnf clean all
 


### PR DESCRIPTION
This reverts commit 5546d7b0e65af8d9680b47a430baf07f970745b2.

The fix for the default Docker seccomp profile containing the clone()
syscall wrapper from glibc 2.34 does not appear to be in the GitHub
Actions `ubuntu-latest` virtual environment yet.

* https://github.com/actions/virtual-environments
* https://github.com/actions/virtual-environments/blob/releases/ubuntu20/20220207/images/linux/Ubuntu2004-Readme.md
