### PR TITLE
Option to override cols/rows of the recorded process

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ Available options:
   to `SHELL,TERM`
 - `-t, --title=<title>` - Specify the title of the asciicast
 - `-i, --idle-time-limit=<sec>` - Limit recorded terminal inactivity to max `<sec>` seconds
+- `--cols=<n>` - Override terminal columns for recorded process
+- `--rows=<n>` - Override terminal rows for recorded process
 - `-y, --yes` - Answer "yes" to all prompts (e.g. upload confirmation)
 - `-q, --quiet` - Be quiet, suppress all notices/warnings (implies -y)
 

--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -12,6 +12,14 @@ from .commands.record import RecordCommand
 from .commands.upload import UploadCommand
 
 
+def positive_int(value: str) -> int:
+    _value = int(value)
+    if _value <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+
+    return _value
+
+
 def positive_float(value: str) -> float:
     _value = float(value)
     if _value <= 0.0:
@@ -119,6 +127,18 @@ For help on a specific command run:
         help="limit recorded idle time to given number of seconds",
         type=positive_float,
         default=maybe_str(cfg.record_idle_time_limit),
+    )
+    parser_rec.add_argument(
+        "--cols",
+        help="override terminal columns for recorded process",
+        type=positive_int,
+        default=None,
+    )
+    parser_rec.add_argument(
+        "--rows",
+        help="override terminal rows for recorded process",
+        type=positive_int,
+        default=None,
     )
     parser_rec.add_argument(
         "-y",

--- a/asciinema/commands/record.py
+++ b/asciinema/commands/record.py
@@ -21,6 +21,8 @@ class RecordCommand(Command):  # pylint: disable=too-many-instance-attributes
         self.title = args.title
         self.assume_yes = args.yes or args.quiet
         self.idle_time_limit = args.idle_time_limit
+        self.cols_override = args.cols
+        self.rows_override = args.rows
         self.append = args.append
         self.overwrite = args.overwrite
         self.raw = args.raw
@@ -109,6 +111,8 @@ class RecordCommand(Command):  # pylint: disable=too-many-instance-attributes
                 writer=self.writer,
                 notifier=self.notifier,
                 key_bindings=self.key_bindings,
+                cols_override=self.cols_override,
+                rows_override=self.rows_override,
             )
         except v2.LoadError:
             self.print_error(

--- a/asciinema/term.py
+++ b/asciinema/term.py
@@ -1,10 +1,9 @@
 import os
 import select
-import subprocess
 import termios as tty  # avoid `Module "tty" has no attribute ...` errors
 from time import sleep
 from tty import setraw
-from typing import IO, Any, List, Optional, Tuple, Union
+from typing import IO, Any, List, Optional, Union
 
 
 class raw:
@@ -33,13 +32,3 @@ def read_blocking(fd: int, timeout: Any) -> bytes:
         return os.read(fd, 1024)
 
     return b""
-
-
-def get_size() -> Tuple[int, int]:
-    try:
-        return os.get_terminal_size()
-    except:  # pylint: disable=bare-except  # noqa: E722
-        return (
-            int(subprocess.check_output(["tput", "cols"])),
-            int(subprocess.check_output(["tput", "lines"])),
-        )

--- a/man/asciinema.1.md
+++ b/man/asciinema.1.md
@@ -93,6 +93,12 @@ Available options:
     `-i, --idle-time-limit=<sec>`
     :   Limit recorded terminal inactivity to max `<sec>` seconds
 
+    `--cols=<n>`
+    :   Override terminal columns for recorded process
+
+    `--rows=<n>`
+    :   Override terminal rows for recorded process
+
     `-y, --yes`
     :   Answer "yes" to all prompts (e.g. upload confirmation)
 

--- a/tests/pty_test.py
+++ b/tests/pty_test.py
@@ -44,6 +44,6 @@ class TestRecord(Test):
                 "; sys.stdout.write('bar')"
             ),
         ]
-        asciinema.pty_.record(command, output)
+        asciinema.pty_.record(command, output, lambda: (80, 24))
 
         assert output.data == [b"foo", b"bar"]


### PR DESCRIPTION
This adds `--cols <n>` / `--rows <n>` options to `rec` command. This disables
autodection of terminal size, and reports fake fixed number of columns/rows to
the recorded process.