### PR TITLE
TTY/stdin/stdout handling improvements

### DIFF
--- a/asciinema/__init__.py
+++ b/asciinema/__init__.py
@@ -19,7 +19,6 @@ def record_asciicast(  # pylint: disable=too-many-arguments
     idle_time_limit: Optional[int] = None,
     record_stdin: bool = False,
     title: Optional[str] = None,
-    metadata: Any = None,
     command_env: Any = None,
     capture_env: Any = None,
 ) -> None:
@@ -30,7 +29,6 @@ def record_asciicast(  # pylint: disable=too-many-arguments
         idle_time_limit=idle_time_limit,
         record_stdin=record_stdin,
         title=title,
-        metadata=metadata,
         command_env=command_env,
         capture_env=capture_env,
     )

--- a/asciinema/commands/command.py
+++ b/asciinema/commands/command.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from typing import Any, Dict, TextIO
 
@@ -21,12 +22,23 @@ class Command:
             print(text, file=file_, end=end)
 
     def print_info(self, text: str) -> None:
-        self.print(f"\x1b[0;32masciinema: {text}\x1b[0m")
+        if os.isatty(sys.stdout.fileno()):
+            self.print(f"\x1b[0;32masciinema: {text}\x1b[0m")
+        else:
+            self.print(f"asciinema: {text}")
 
     def print_warning(self, text: str) -> None:
-        self.print(f"\x1b[0;33masciinema: {text}\x1b[0m")
+        if os.isatty(sys.stdout.fileno()):
+            self.print(f"\x1b[0;33masciinema: {text}\x1b[0m")
+        else:
+            self.print(f"asciinema: {text}")
 
     def print_error(self, text: str) -> None:
-        self.print(
-            f"\x1b[0;31masciinema: {text}\x1b[0m", file_=sys.stderr, force=True
-        )
+        if os.isatty(sys.stderr.fileno()):
+            self.print(
+                f"\x1b[0;31masciinema: {text}\x1b[0m",
+                file_=sys.stderr,
+                force=True,
+            )
+        else:
+            self.print(f"asciinema: {text}", file_=sys.stderr, force=True)

--- a/asciinema/pty_.py
+++ b/asciinema/pty_.py
@@ -112,6 +112,11 @@ def record(
 
         fds = [master_fd, tty_stdin_fd, signal_fd]
 
+        stdin_fd = pty.STDIN_FILENO
+
+        if not os.isatty(stdin_fd):
+            fds.append(stdin_fd)
+
         while True:
             try:
                 rfds, _, _ = select.select(fds, [], [])
@@ -130,6 +135,13 @@ def record(
                 data = os.read(tty_stdin_fd, 1024)
                 if not data:
                     fds.remove(tty_stdin_fd)
+                else:
+                    _handle_stdin_read(data)
+
+            if stdin_fd in rfds:
+                data = os.read(stdin_fd, 1024)
+                if not data:
+                    fds.remove(stdin_fd)
                 else:
                     _handle_stdin_read(data)
 

--- a/asciinema/recorder.py
+++ b/asciinema/recorder.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import Any, Callable, Dict, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
 from . import pty_ as pty  # avoid collisions with standard library `pty`
 from .asciicast import v2
@@ -10,14 +10,13 @@ from .async_worker import async_worker
 
 def record(  # pylint: disable=too-many-arguments,too-many-locals
     path_: str,
-    command: Any = None,
+    command: Optional[str] = None,
     append: bool = False,
-    idle_time_limit: Optional[int] = None,
+    idle_time_limit: Optional[float] = None,
     record_stdin: bool = False,
     title: Optional[str] = None,
-    metadata: Any = None,
-    command_env: Optional[Dict[Any, Any]] = None,
-    capture_env: Any = None,
+    command_env: Optional[Dict[str, str]] = None,
+    capture_env: Optional[List[str]] = None,
     writer: Type[w2] = v2.writer,
     record_: Callable[..., None] = pty.record,
     notify: Callable[[str], None] = lambda _: None,


### PR DESCRIPTION
- use real tty (/dev/tty) instead of asciinema's stdin/stdout for recorded process' input/output - allows redirecting asciinema output (logger) while keeping recorded process' output visible
- fallback to /dev/null for input/output when tty is not available (when recording headless)
- don't use esc sequences (colors) in logger when asciinema's own output is redirected to a file/pipe
- forward asciinema's own stdin to recorded process - allows driving interactive programs in headless mode