### PR TITLE
Add `--out-fmt` option to `play` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,11 +293,19 @@ Available options:
 
 - `-i, --idle-time-limit=<sec>` - Limit replayed terminal inactivity to max `<sec>` seconds
 - `-s, --speed=<factor>` - Playback speed (can be fractional)
-- `--stream=<stream>` - Recorded stream to play (see below)
+- `--stream=<stream>` - Select stream to play (see below)
+- `--out-fmt=<format>` - Select output format (see below)
 
 By default the output stream (`o`) is played. This is what you want in most
 cases.  If you recorded the input stream (`i`) with `asciinema rec --stdin` then
 you can replay it with `asciinema play --stream=i <filename>`.
+
+By default the selected stream is written to stdout in original, raw data form.
+This is also what you want in majority of cases. However you can change the
+output format to asciicast (newline delimited JSON) with `asciinema play
+--out-fmt=asciicast <filename>`. This allows delegating actual rendering to
+another place (e.g. outside of your terminal) by piping output of `asciinema
+play` to a tool of your choice.
 
 > For the best playback experience it is recommended to run `asciinema play` in
 > a terminal of dimensions not smaller than the one used for recording, as

--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -179,6 +179,12 @@ For help on a specific command run:
         default=cfg.play_speed,
     )
     parser_play.add_argument(
+        "--out-fmt",
+        help="output format",
+        choices=["raw", "asciicast"],
+        default="raw",
+    )
+    parser_play.add_argument(
         "--stream",
         help="recorded stream to play (o, i)",
         default="o",

--- a/asciinema/asciicast/v1.py
+++ b/asciinema/asciicast/v1.py
@@ -35,7 +35,7 @@ class Asciicast:
         }
         return header
 
-    def events(self, type_: Optional[str]) -> Iterable[List[Any]]:
+    def events(self, type_: Optional[str] = None) -> Iterable[List[Any]]:
         if type_ in [None, "o"]:
             return to_absolute_time(self.__stdout_events())
         else:

--- a/asciinema/asciicast/v2.py
+++ b/asciinema/asciicast/v2.py
@@ -31,7 +31,9 @@ class Asciicast:
         self.v2_header = header
         self.idle_time_limit = header.get("idle_time_limit")
 
-    def events(self, type_: Optional[str]) -> Generator[List[Any], None, None]:
+    def events(
+        self, type_: Optional[str] = None
+    ) -> Generator[List[Any], None, None]:
         if type_ is None:
             for line in self.__file:
                 yield json.loads(line)

--- a/asciinema/commands/play.py
+++ b/asciinema/commands/play.py
@@ -18,6 +18,7 @@ class PlayCommand(Command):
         self.filename = args.filename
         self.idle_time_limit = args.idle_time_limit
         self.speed = args.speed
+        self.out_fmt = args.out_fmt
         self.stream = args.stream
         self.player = player if player is not None else Player()
         self.key_bindings = {
@@ -33,6 +34,7 @@ class PlayCommand(Command):
                     idle_time_limit=self.idle_time_limit,
                     speed=self.speed,
                     key_bindings=self.key_bindings,
+                    out_fmt=self.out_fmt,
                     stream=self.stream,
                 )
 


### PR DESCRIPTION
Implements playback output in asciicast format, allowing it to be streamed elsewhere.