### PR TITLE
Fix piping of input into `rec` command

### DIFF
--- a/asciinema/async_worker.py
+++ b/asciinema/async_worker.py
@@ -20,11 +20,11 @@ class async_worker:
         self.process: Optional[Process] = None
 
     def __enter__(self) -> Any:
-        self.process = Process(target=self.__run)
+        self.process = Process(target=self._run)
         self.process.start()
         return self
 
-    def __run(self) -> None:
+    def _run(self) -> None:
         try:
             self.run()
         except KeyboardInterrupt:

--- a/asciinema/async_worker.py
+++ b/asciinema/async_worker.py
@@ -20,9 +20,15 @@ class async_worker:
         self.process: Optional[Process] = None
 
     def __enter__(self) -> Any:
-        self.process = Process(target=self.run)
+        self.process = Process(target=self.__run)
         self.process.start()
         return self
+
+    def __run(self) -> None:
+        try:
+            self.run()
+        except KeyboardInterrupt:
+            pass
 
     def __exit__(
         self, exc_type: str, exc_value: str, exc_traceback: str

--- a/asciinema/pty_.py
+++ b/asciinema/pty_.py
@@ -1,12 +1,10 @@
 import array
-import errno
 import fcntl
 import os
 import pty
 import select
 import signal
 import struct
-import sys
 import termios
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple

--- a/asciinema/pty_.py
+++ b/asciinema/pty_.py
@@ -6,6 +6,7 @@ import pty
 import select
 import signal
 import struct
+import sys
 import termios
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -91,23 +92,24 @@ def record(
 
     def copy(signal_fd: int) -> None:  # pylint: disable=too-many-branches
         fds = [pty_fd, tty_stdin_fd, signal_fd]
-        stdin_fd = pty.STDIN_FILENO
-
-        if not os.isatty(stdin_fd):
-            fds.append(stdin_fd)
 
         while True:
             try:
                 rfds, _, _ = select.select(fds, [], [])
-            except OSError as e:  # Python >= 3.3
-                if e.errno == errno.EINTR:
-                    continue
+            except KeyboardInterrupt:
+                if tty_stdin_fd in fds:
+                    fds.remove(tty_stdin_fd)
+
+                break
 
             if pty_fd in rfds:
-                data = os.read(pty_fd, 1024)
+                try:
+                    data = os.read(pty_fd, 1024)
+                except OSError as e:
+                    data = b""
 
                 if not data:  # Reached EOF.
-                    fds.remove(pty_fd)
+                    break
                 else:
                     handle_master_read(data)
 
@@ -115,15 +117,8 @@ def record(
                 data = os.read(tty_stdin_fd, 1024)
 
                 if not data:
-                    fds.remove(tty_stdin_fd)
-                else:
-                    handle_stdin_read(data)
-
-            if stdin_fd in rfds:
-                data = os.read(stdin_fd, 1024)
-
-                if not data:
-                    fds.remove(stdin_fd)
+                    if tty_stdin_fd in fds:
+                        fds.remove(tty_stdin_fd)
                 else:
                     handle_stdin_read(data)
 
@@ -135,8 +130,7 @@ def record(
 
                     for sig in signals:
                         if sig in EXIT_SIGNALS:
-                            os.close(pty_fd)
-                            return None
+                            fds.remove(signal_fd)
                         if sig == signal.SIGWINCH:
                             set_pty_size()
 
@@ -152,6 +146,7 @@ def record(
         with raw(tty_stdin_fd):
             try:
                 copy(sig_fd)
+                os.close(pty_fd)
             except (IOError, OSError):
                 pass
 

--- a/asciinema/recorder.py
+++ b/asciinema/recorder.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 from typing import Any, Callable, Dict, List, Optional, TextIO, Tuple, Type
 
@@ -78,21 +79,14 @@ class tty_fds:
 
     def __enter__(self) -> Tuple[int, int]:
         try:
-            self.stdin_file = open("/dev/tty", "rt", encoding="utf_8")
-        except OSError:
-            self.stdin_file = open("/dev/null", "rt", encoding="utf_8")
-
-        try:
             self.stdout_file = open("/dev/tty", "wt", encoding="utf_8")
         except OSError:
             self.stdout_file = open("/dev/null", "wt", encoding="utf_8")
 
-        return (self.stdin_file.fileno(), self.stdout_file.fileno())
+        return (sys.stdin.fileno(), self.stdout_file.fileno())
 
     def __exit__(self, type_: str, value: str, traceback: str) -> None:
-        assert self.stdin_file is not None
         assert self.stdout_file is not None
-        self.stdin_file.close()
         self.stdout_file.close()
 
 


### PR DESCRIPTION
This improves input handling for `rec` command:

- we now always read keys from stdin only, while previously we read from both stdin and directly from tty, which was problematic when piping
- keyboard interrupt is now handled in a more graceful way