### PR TITLE
Add shell completions by shtab

### DIFF
--- a/asciinema/_shtab.py
+++ b/asciinema/_shtab.py
@@ -1,0 +1,14 @@
+from argparse import ArgumentParser
+from typing import Any
+
+FILE = None
+DIRECTORY = DIR = None
+
+
+def add_argument_to(
+    parser: ArgumentParser, *args: list[Any], **kwargs: dict[str, Any]
+) -> ArgumentParser:
+    from argparse import Action
+
+    Action.complete = None  # type: ignore
+    return parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,10 @@ packages =
     asciinema.commands
 install_requires =
 
+[options.extras_require]
+completion =
+    shtab
+
 [options.package_data]
 asciinema = data/*.png
 


### PR DESCRIPTION
```sh
asciinema --print-completion bash | sudo tee /usr/share/bash-completion/completions/asciinema
asciinema --print-completion zsh | sudo tee /usr/share/zsh/site-functions/_asciinema
asciinema --print-completion tcsh | sudo tee /etc/profile.d/asciinema.completion.csh
```

```sh
❯ asciinema <TAB>
asciinema commands
auth
cat
play
rec
upload
❯ asciinema play --<TAB>
option
--help              show this help message and exit
--idle-time-limit   limit idle time during playback to given number of seconds
--loop              loop loop loop loop
--out-fmt           select output format
--speed             set playback speed (can be fractional)
--stream            select stream to play
❯ asciinema play --out-fmt <TAB>
out_fmt
asciicast  raw
```

It should can replace
<https://github.com/zsh-users/zsh/blob/master/Completion/Unix/Command/_asciinema>.
Because this PR is generated from argparse automatically. But the latter is 
written manually.

I use some `type:ignore`. It is not elegant. Does any better method exist?
