### PR TITLE
Add `--suppress-output` flag to `record` command

### DIFF
--- a/asciinema/__init__.py
+++ b/asciinema/__init__.py
@@ -21,6 +21,7 @@ def record_asciicast(  # pylint: disable=too-many-arguments
     title: Optional[str] = None,
     command_env: Any = None,
     capture_env: Any = None,
+    suppress_output: Optional[bool] = False,
 ) -> None:
     record(
         path_,
@@ -31,4 +32,5 @@ def record_asciicast(  # pylint: disable=too-many-arguments
         title=title,
         command_env=command_env,
         capture_env=capture_env,
+        suppress_output=suppress_output,
     )

--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -166,6 +166,12 @@ For help on a specific command run:
         default=cfg.record_quiet,
     )
     parser_rec.add_argument(
+        "--suppress-output",
+        help="suppress output from the recorded session",
+        action="store_true",
+        default=cfg.suppress_output,
+    )
+    parser_rec.add_argument(
         "filename",
         nargs="?",
         default="",

--- a/asciinema/commands/record.py
+++ b/asciinema/commands/record.py
@@ -35,6 +35,7 @@ class RecordCommand(Command):  # pylint: disable=too-many-instance-attributes
             "prefix": config.record_prefix_key,
             "pause": config.record_pause_key,
         }
+        self.suppress_output = args.suppress_output
 
     # pylint: disable=too-many-branches
     # pylint: disable=too-many-return-statements
@@ -137,6 +138,7 @@ class RecordCommand(Command):  # pylint: disable=too-many-instance-attributes
                 key_bindings=self.key_bindings,
                 cols_override=self.cols_override,
                 rows_override=self.rows_override,
+                suppress_output=self.suppress_output,
             )
         except IOError as e:
             self.print_error(f"I/O error: {str(e)}")

--- a/asciinema/config.py
+++ b/asciinema/config.py
@@ -167,6 +167,10 @@ class Config:
     def notifications_command(self) -> Optional[str]:
         return self.config.get("notifications", "command", fallback=None)
 
+    @property
+    def suppress_output(self) -> bool:
+        return self.config.getboolean("record", "suppress_output", fallback=False)
+
     def __get_key(self, section: str, name: str, default: Any = None) -> Any:
         key = self.config.get(section, f"{name}_key", fallback=default)
 

--- a/asciinema/pty_.py
+++ b/asciinema/pty_.py
@@ -29,6 +29,7 @@ def record(
     key_bindings: Dict[str, Any],
     tty_stdin_fd: int = pty.STDIN_FILENO,
     tty_stdout_fd: int = pty.STDOUT_FILENO,
+    suppress_output: Optional[bool] = False,
 ) -> None:
     pty_fd: Any = None
     start_time: Optional[float] = None
@@ -43,7 +44,8 @@ def record(
         fcntl.ioctl(pty_fd, termios.TIOCSWINSZ, buf)
 
     def handle_master_read(data: Any) -> None:
-        os.write(tty_stdout_fd, data)
+        if not suppress_output:
+            os.write(tty_stdout_fd, data)
 
         if not pause_time:
             assert start_time is not None

--- a/asciinema/recorder.py
+++ b/asciinema/recorder.py
@@ -24,6 +24,7 @@ def record(  # pylint: disable=too-many-arguments,too-many-locals
     key_bindings: Optional[Dict[str, Any]] = None,
     cols_override: Optional[int] = None,
     rows_override: Optional[int] = None,
+    suppress_output: Optional[bool] = False,
 ) -> None:
     if command is None:
         command = os.environ.get("SHELL", "sh")
@@ -69,6 +70,7 @@ def record(  # pylint: disable=too-many-arguments,too-many-locals
                 key_bindings,
                 tty_stdin_fd=tty_stdin_fd,
                 tty_stdout_fd=tty_stdout_fd,
+                suppress_output=suppress_output,
             )
 
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -216,3 +216,14 @@ def test_notifications_command() -> None:
         '[notifications]\ncommand = tmux display-message "$TEXT"'
     )
     assert config.notifications_command == 'tmux display-message "$TEXT"'
+
+
+def test_record_suppress_yes() -> None:
+    yes = "yes"
+    config = create_config(f"[record]\nsuppress_output = {yes}")
+    assert config.suppress_output is True
+
+
+def test_default_record_supress() -> None:
+    config = create_config("")
+    assert config.suppress_output is False

--- a/tests/pty_test.py
+++ b/tests/pty_test.py
@@ -1,3 +1,4 @@
+import pytest
 import os
 import pty
 from typing import Any, List, Union
@@ -52,3 +53,60 @@ class TestRecord(Test):
         )
 
         assert writer.data == [b"foo", b"bar"]
+
+    @staticmethod
+    def test_unsupressed_record_command_writes_to_fd() -> None:
+        writer = Writer()
+
+        command = [
+            "python3",
+            "-c",
+            (
+                "import sys"
+                "; import time"
+                "; sys.stdout.write('foo')"
+                "; sys.stdout.flush()"
+                "; time.sleep(0.01)"
+                "; sys.stdout.write('bar')"
+            ),
+        ]
+
+        rfd, wfd = os.pipe()
+        asciinema.pty_.record(
+            command, {}, writer, lambda: (80, 24), lambda s: None, {}, tty_stdout_fd=wfd,
+        )
+
+        assert writer.data == [b"foo", b"bar"]
+        assert os.read(rfd, 100) == b"foobar"
+
+    @staticmethod
+    def test_supressed_record_command_does_not_write_to_fd() -> None:
+        writer = Writer()
+
+        command = [
+            "python3",
+            "-c",
+            (
+                "import sys"
+                "; import time"
+                "; sys.stdout.write('foo')"
+                "; sys.stdout.flush()"
+                "; time.sleep(0.01)"
+                "; sys.stdout.write('bar')"
+            ),
+        ]
+
+        rfd, wfd = os.pipe()
+        asciinema.pty_.record(
+            command, {}, writer, lambda: (80, 24), lambda s: None, {}, tty_stdout_fd=wfd,
+            suppress_output=True,
+        )
+
+        assert writer.data == [b"foo", b"bar"]
+        # As we pass `suppress_output=True`, we expect `tty_stdout_fd` to never be written to.
+        # As the pipe is empty, calling `os.read` on it will block forever
+        # We use the raise `BlockingIOError` as a signal that the pipe is empty,
+        # which means `pty_.record` did not write anything to `tty_stdout_fd`.
+        os.set_blocking(rfd, False)
+        with pytest.raises(BlockingIOError):
+            assert os.read(rfd, 100) == b""


### PR DESCRIPTION
Hi

This PR implements a new flag for the `record` command: `--suppress-output`.
This allows certain use-cases, like running recorded integration tests in CI without the commands' output polluting logs.

I've only added unit-tests, as I could not get the expected integration test to work in `asciinema` before my changes:

```
$ asciinema rec --overwrite -q  -c "echo 'this is a very nice message'" out.rec | wc -c
this is a very nice message
0
```
I would've expected `wc` to return `28`.

Which I'd have compared with
```
$ asciinema rec --overwrite -q --suppress-output  -c "echo 'this is a very nice message'" out.rec  | wc -c
0
$
```