### PR TITLE
Make `cat` subcommand be capable to actually concatenate multiple recordings

### DIFF
--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -222,10 +222,10 @@ For help on a specific command run:
 
     # create the parser for the `cat` command
     parser_cat = subparsers.add_parser(
-        "cat", help="Print full output of terminal session"
+        "cat", help="Print full output of terminal sessions"
     )
     parser_cat.add_argument(
-        "filename", help='local path, http/ipfs URL or "-" (read from stdin)'
+        "filename", nargs="+", help='local path, http/ipfs URL or "-" (read from stdin)'
     )
     parser_cat.set_defaults(cmd=CatCommand)
 

--- a/asciinema/commands/cat.py
+++ b/asciinema/commands/cat.py
@@ -10,7 +10,7 @@ from .command import Command
 class CatCommand(Command):
     def __init__(self, args: Any, config: Config, env: Dict[str, str]):
         Command.__init__(self, args, config, env)
-        self.filename = args.filename
+        self.filenames = args.filename
 
     def execute(self) -> int:
         try:
@@ -22,10 +22,11 @@ class CatCommand(Command):
 
     def cat(self) -> int:
         try:
-            with asciicast.open_from_url(self.filename) as a:
-                for _, _type, text in a.events("o"):
-                    sys.stdout.write(text)
-                    sys.stdout.flush()
+            for filename in self.filenames:
+                with asciicast.open_from_url(filename) as a:
+                    for _, _type, text in a.events("o"):
+                        sys.stdout.write(text)
+                        sys.stdout.flush()
 
         except asciicast.LoadError as e:
             self.print_error(f"printing failed: {str(e)}")


### PR DESCRIPTION
Despite its name, the `cat` subcommand accepts only 1 input file, and can't really be used to concatenate multiple files.

Making it a true `cat` would be useful at least to myself.