### PR TITLE
Terminal resize capture

### DIFF
--- a/asciinema/asciicast/raw.py
+++ b/asciinema/asciicast/raw.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from os import path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Tuple
 
 from ..file_writer import file_writer
 
@@ -44,12 +44,15 @@ class writer(file_writer):
     def write_stdout(self, _ts: float, data: Any) -> None:
         self._write(data)
 
-    # pylint: disable=no-self-use
     def write_stdin(self, ts: float, data: Any) -> None:
         pass
 
     def write_marker(self, ts: float) -> None:
         pass
+
+    def write_resize(self, ts: float, size: Tuple[int, int]) -> None:
+        cols, rows = size
+        self._write(f"\x1b[8;{rows};{cols}t".encode("utf-8"))
 
     # pylint: disable=consider-using-with
     def _open_file(self) -> None:

--- a/asciinema/asciicast/v2.py
+++ b/asciinema/asciicast/v2.py
@@ -12,6 +12,7 @@ from typing import (
     List,
     Optional,
     TextIO,
+    Tuple,
     Union,
 )
 
@@ -147,6 +148,10 @@ class writer(file_writer):
 
     def write_marker(self, ts: float) -> None:
         self.__write_event(ts, "m", "")
+
+    def write_resize(self, ts: float, size: Tuple[int, int]) -> None:
+        cols, rows = size
+        self.__write_event(ts, "r", f"{cols}x{rows}")
 
     # pylint: disable=consider-using-with
     def _open_file(self) -> None:

--- a/asciinema/recorder.py
+++ b/asciinema/recorder.py
@@ -134,6 +134,9 @@ class async_writer(async_worker):
     def write_marker(self, ts: float) -> None:
         self.enqueue([ts, "m", None])
 
+    def write_resize(self, ts: float, size: Tuple[int, int]) -> None:
+        self.enqueue([ts, "r", size])
+
     def run(self) -> None:
         try:
             with self.writer as w:
@@ -148,6 +151,8 @@ class async_writer(async_worker):
                         w.write_stdin(self.time_offset + ts, data)
                     elif etype == "m":
                         w.write_marker(self.time_offset + ts)
+                    elif etype == "r":
+                        w.write_resize(self.time_offset + ts, data)
         except IOError:
             for event in iter(self.queue.get, None):
                 pass

--- a/doc/asciicast-v2.md
+++ b/doc/asciicast-v2.md
@@ -15,6 +15,7 @@ Example file:
 [1.001376, "o", "That was ok\rThis is better."]
 [1.500000, "m", ""]
 [2.143733, "o", "Now... "]
+[4.050000, "r", "80x24"]
 [6.541828, "o", "Bye!"]
 ```
 
@@ -115,7 +116,7 @@ Where:
 
 * `time` (float) - indicates when this event happened, represented as the number
   of seconds since the beginning of the recording session,
-* `event-type` (string) - one of: `"o"`, `"i"`, `"m"`
+* `event-type` (string) - one of: `"o"`, `"i"`, `"m"`, `"r"`
 * `event-data` (any) - event specific data, described separately for each event
   type.
 
@@ -175,6 +176,13 @@ the user to resume.
 
 `event-data` can be used to annotate a marker. Annotations may be used to e.g.
 show a list of named "chapters".
+
+#### "r" - resize
+
+Event of type `"r"` represents terminal resize.
+
+`event-data` contains new terminal size (columns + rows) formatted as
+`"{COLS}x{ROWS}"`, e.g. `"80x24"`.
 
 ## Notes on compatibility
 


### PR DESCRIPTION
This saves new resize event, `r`, which can be used by the player to resize its view.

Fixes #140 