### PR TITLE
Ignore BlockingIOError when trying to write pty master fd

### DIFF
--- a/asciinema/pty_.py
+++ b/asciinema/pty_.py
@@ -158,8 +158,11 @@ def record(
                             handle_resize()
 
             if pty_fd in wfds:
-                n = os.write(pty_fd, input_data)
-                input_data = input_data[n:]
+                try:
+                    n = os.write(pty_fd, input_data)
+                    input_data = input_data[n:]
+                except BlockingIOError:
+                    pass
 
     pid, pty_fd = pty.fork()
 


### PR DESCRIPTION
After #556, **asciinema(1)** will **write(2)** the pty master fd only when **select(2)** indicated that it is ready to write; however when using the fixed version one day, I encountered another issue which caused **asciinema(1)** to silently exit without any error message.

So far I can only reproduce this issue on a particular machine, here's my troubleshooting steps:

* I found that some try-except codes hide the error messages completely, so I temporarily removed such codes to show the full error and stacktrace:
```diff
diff --git a/asciinema/commands/record.py b/asciinema/commands/record.py
index e60002d..a11bfe7 100644
--- a/asciinema/commands/record.py
+++ b/asciinema/commands/record.py
@@ -139,9 +139,6 @@ class RecordCommand(Command):  # pylint: disable=too-many-instance-attributes
                 cols_override=self.cols_override,
                 rows_override=self.rows_override,
             )
-        except IOError as e:
-            self.print_error(f"I/O error: {str(e)}")
-            return 1
         except v2.LoadError:
             self.print_error(
                 "can only append to asciicast v2 format recordings"
diff --git a/asciinema/pty_.py b/asciinema/pty_.py
index 4f5f18a..d2579f3 100644
--- a/asciinema/pty_.py
+++ b/asciinema/pty_.py
@@ -174,11 +174,8 @@ def record(
 
     with SignalFD(EXIT_SIGNALS + [signal.SIGWINCH]) as sig_fd:
         with raw(tty_stdin_fd):
-            try:
-                copy(sig_fd)
-                os.close(pty_fd)
-            except (IOError, OSError):
-                pass
+            copy(sig_fd)
+            os.close(pty_fd)
 
     os.waitpid(pid, 0)
 
```
* Start a recording session using the modified version (my default shell **bash(1)** is now running inside)
* Prepare large amount of text and put it in X11 primary selection, in another terminal window; this time I chosen to use the backspace character instead of `w` to avoid flushing out any error message:
```sh
i=0; while [ $i -lt 20000 ]; do printf '\b\b\b\b\b\b\b\b\b\b'; i=$((i+1)); done | xclip -verbose -selection primary -in -target text/plain
```
* Paste it into the recording terminal (which will be noisy if terminal bell is enabled)
* Repeat last step until **asciinema(1)** exits due to unhandled exception, the error message I got was
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/home/WHR/src/asciinema/asciinema/__main__.py", line 262, in <module>
    sys.exit(main())
  File "/usr/home/WHR/src/asciinema/asciinema/__main__.py", line 254, in main
    code = command.execute()
  File "/usr/home/WHR/src/asciinema/asciinema/commands/record.py", line 140, in execute
    rows_override=self.rows_override,
  File "/usr/home/WHR/src/asciinema/asciinema/recorder.py", line 71, in record
    tty_stdout_fd=tty_stdout_fd,
  File "/usr/home/WHR/src/asciinema/asciinema/pty_.py", line 177, in record
    copy(sig_fd)
  File "/usr/home/WHR/src/asciinema/asciinema/pty_.py", line 161, in copy
    n = os.write(pty_fd, input_data)
BlockingIOError: [Errno 35] Resource temporarily unavailable
```

I also made another try with **truss(1)** attached, here's the truss log:
```
80630: select(12,{ 0 10 11 },{ },{ },0x0)        = 1 (0x1)
80630: _umtx_op(0x8059071b8,UMTX_OP_NWAKE_PRIVATE,0x1,0x0,0x0) = 0 (0x0)
80630: _umtx_op(0x8006edc20,UMTX_OP_WAIT_UINT_PRIVATE,0x0,0x18,0x7fffffff0fc8) = 0 (0x0)
80630: read(10,"\a\a\a\a\a\a\a\a\a\a\a\a\a\a\a\a"...,262144) = 400 (0x190)
80630: write(3,"\a\a\a\a\a\a\a\a\a\a\a\a\a\a\a\a"...,400) = 400 (0x190)
80630: write(8,"\0\0\0\M-|\M^@\^C]q\0(G@]\M^Pf"...,256) = 256 (0x100)
80630: write(8,"\0\0\^A\M-0\M^@\^C]q\0(G@]\M^P"...,436) = 436 (0x1b4)
80630: select(12,{ 0 10 11 },{ },{ },0x0)        = 1 (0x1)
80630: read(10,"\a",262144)                      = 1 (0x1)
80630: write(3,"\a",1)                           = 1 (0x1)
80630: _umtx_op(0x805b7c014,UMTX_OP_SEM2_WAKE,0x0,0x0,0x0) = 0 (0x0)
80630: select(12,{ 0 10 11 },{ },{ },0x0)        = 1 (0x1)
80630: read(10,"\a\a\a\a\a\a\a\a\a\a\a\a\a\a\a\a"...,262144) = 758 (0x2f6)
80630: write(3,"\a\a\a\a\a\a\a\a\a\a\a\a\a\a\a\a"...,758) = 758 (0x2f6)
80630: _umtx_op(0x805b7c014,UMTX_OP_SEM2_WAIT,0x0,0x0,0x0) = 0 (0x0)
80630: write(8,"\0\0\0\^^\M^@\^C]q\0(G@]\M^P\M-$"...,34) = 34 (0x22)
80630: write(8,"\0\0\^C\^V\M^@\^C]q\0(G@]\M^P"...,794) = 794 (0x31a)
80630: select(12,{ 0 10 11 },{ },{ },0x0)        = 1 (0x1)
80630: read(0,"\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b"...,262144) = 1920 (0x780)
80630: select(12,{ 0 10 11 },{ 10 },{ },0x0)     = 1 (0x1)
80630: write(10,"\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b"...,1920) = 1920 (0x780)
80630: select(12,{ 0 10 11 },{ },{ },0x0)        = 1 (0x1)
80630: read(0,"\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b"...,262144) = 1920 (0x780)
80630: select(12,{ 0 10 11 },{ 10 },{ },0x0)     = 1 (0x1)
80630: write(10,"\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b"...,1920) ERR#35 'Resource temporarily unavailable'
```

Apparently the last **select(2)** returned and kept fd 10 in write fd set (which didn't shown here since this **truss(1)** didn't give the states of fd sets after **select(2)** returns, but it has to be this way because that **write(2)** was called immediately after **select(2)**, indicating fd 10 was the only fd returned by **select(2)**); despite this the later **write(2)** call still fails with `EAGAIN`, as if this **select(2)** has lied to me about the fd state.

To workaround this issue, I put the **write(2)** call in a try-except block to ignore `BlockingIOError` which would be genetated from `EAGAIN`; the failed call will simply be retried in next select loop.