### PR TITLE
Require explicit upload choice when recording without file arg

### DIFF
--- a/asciinema/commands/command.py
+++ b/asciinema/commands/command.py
@@ -17,12 +17,16 @@ class Command:
         end: str = "\r\n",
         color: Optional[int] = None,
         force: bool = False,
+        flush: bool = False,
     ) -> None:
         if not self.quiet or force:
             if color is not None and os.isatty(sys.stderr.fileno()):
                 text = f"\x1b[0;3{color}m{text}\x1b[0m"
 
             print(text, file=sys.stderr, end=end)
+
+            if flush:
+                sys.stderr.flush()
 
     def print_info(self, text: str) -> None:
         self.print(f"asciinema: {text}", color=2)


### PR DESCRIPTION
This changes the prompt for upload from simply accepting `<enter>` key as upload confirmation to requiring explicitly typing `u<enter>`. Also, lets saving locally in tmp directory (what was previously achieved with `<ctrl-c>`, and adds discard option too.

```
$ asciinema rec
asciinema: recording asciicast to /tmp/tmpo8_612f8-ascii.cast
asciinema: press <ctrl-d> or type "exit" when you're done
$ echo hello
hello
$ exit 
asciinema: recording finished
(s)ave locally, (u)pload to asciinema.org, (d)iscard
[s,u,d]? _
```

If none of `s`, `u`, `d` are entered (which includes just hitting enter) then the prompt is displayed again, until valid choice is made. `<ctrl-c>` works as it did in previous versions, which is equivalent to `s` (save).

Discussed in:
- https://github.com/orgs/asciinema/discussions/21
- https://github.com/orgs/asciinema/discussions/31