### PR TITLE
Re-enable default signal handler for SIGPIPE in child process

### DIFF
--- a/asciinema/pty_.py
+++ b/asciinema/pty_.py
@@ -167,6 +167,7 @@ def record(
     pid, pty_fd = pty.fork()
 
     if pid == pty.CHILD:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
         os.execvpe(command[0], command, env)
 
     flags = fcntl.fcntl(pty_fd, fcntl.F_GETFL, 0) | os.O_NONBLOCK


### PR DESCRIPTION
Fix for #369.

asciinema parent process doesn't set handler for SIGPIPE, which by default sets SIG_IGN for this signal in a child process. This explicitly sets the handler in the child process to SIG_DFL.

This is something script and mosh do right before exec-ing the command in a child process:

script - https://github.com/util-linux/util-linux/blob/f3fd64111c28de1ecd47f7cd519120ffa531800d/term-utils/script.c#L987
mosh - https://github.com/mobile-shell/mosh/blob/1105d481bb9143dad43adf768f58da7b029fd39c/src/frontend/mosh-server.cc#L540-L546

Many thanks to @Low-power for figuring this out :clap: 