### PR TITLE
New implementation of the auth command

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,3 +59,16 @@ fn build_user_agent() -> String {
 
     ua.to_owned()
 }
+
+pub fn auth(server_url: String) -> Result<()> {
+    let mut auth_url = Url::parse(&server_url)?;
+    let install_id = util::get_install_id()?;
+    auth_url.set_path(&format!("connect/{install_id}"));
+    let server_hostname = auth_url.host().ok_or(anyhow!("invalid server URL"))?;
+
+    println!("Open the following URL in a web browser to authenticate this asciinema CLI with your {server_hostname} user account:\n");
+    println!("{}\n", auth_url);
+    println!("This action will associate all recordings uploaded from this machine (past and future ones) with your account, allowing you to manage them (change the title/theme, delete) at {server_hostname}.");
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,10 @@ enum Commands {
     },
 
     /// Link this system to asciinema.org account
-    Auth,
+    Auth {
+        /// asciinema server URL
+        server_url: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -199,7 +202,9 @@ fn main() -> Result<()> {
             asciinema::upload(filename, server_url)?;
         }
 
-        Commands::Auth => todo!(),
+        Commands::Auth { server_url } => {
+            asciinema::auth(server_url)?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
No hard-coded server URL, requires explicit server URL as the first argument to `auth`:

```sh
asciinema auth https://asciinema.org
```