### PR TITLE
New impl of `cat` command

### DIFF
--- a/src/cmd/cat.rs
+++ b/src/cmd/cat.rs
@@ -1,5 +1,7 @@
+use crate::format::asciicast;
 use anyhow::Result;
 use clap::Args;
+use std::{fs, io};
 
 #[derive(Debug, Args)]
 pub struct Cli {
@@ -9,6 +11,30 @@ pub struct Cli {
 
 impl Cli {
     pub fn run(self) -> Result<()> {
-        todo!();
+        let mut writer = asciicast::Writer::new(io::stdout(), 0);
+        let mut time_offset: u64 = 0;
+        let mut first = true;
+
+        for path in self.filename.iter() {
+            let reader = io::BufReader::new(fs::File::open(path)?);
+            let (header, events) = asciicast::open(reader)?;
+            let mut time = time_offset;
+
+            if first {
+                writer.write_header(&header)?;
+                first = false;
+            }
+
+            for event in events {
+                let mut event = event?;
+                time = time_offset + event.time;
+                event.time = time;
+                writer.write_event(event)?;
+            }
+
+            time_offset = time;
+        }
+
+        Ok(())
     }
 }

--- a/src/cmd/rec.rs
+++ b/src/cmd/rec.rs
@@ -94,7 +94,7 @@ impl Cli {
             let time_offset = if append {
                 asciicast::get_duration(&self.filename)?
             } else {
-                0.0
+                0
             };
 
             Box::new(asciicast::Writer::new(file, time_offset))

--- a/src/format.rs
+++ b/src/format.rs
@@ -4,9 +4,9 @@ use std::{collections::HashMap, io};
 
 pub trait Writer {
     fn header(&mut self, header: &Header) -> io::Result<()>;
-    fn output(&mut self, time: f64, data: &[u8]) -> io::Result<()>;
-    fn input(&mut self, time: f64, data: &[u8]) -> io::Result<()>;
-    fn resize(&mut self, time: f64, size: (u16, u16)) -> io::Result<()>;
+    fn output(&mut self, time: u64, data: &[u8]) -> io::Result<()>;
+    fn input(&mut self, time: u64, data: &[u8]) -> io::Result<()>;
+    fn resize(&mut self, time: u64, size: (u16, u16)) -> io::Result<()>;
 }
 
 pub struct Header {

--- a/src/format/raw.rs
+++ b/src/format/raw.rs
@@ -15,15 +15,15 @@ impl<W: Write> super::Writer for Writer<W> {
         write!(self.writer, "\x1b[8;{};{}t", header.rows, header.cols)
     }
 
-    fn output(&mut self, _time: f64, data: &[u8]) -> io::Result<()> {
+    fn output(&mut self, _time: u64, data: &[u8]) -> io::Result<()> {
         self.writer.write_all(data)
     }
 
-    fn input(&mut self, _time: f64, _data: &[u8]) -> io::Result<()> {
+    fn input(&mut self, _time: u64, _data: &[u8]) -> io::Result<()> {
         Ok(())
     }
 
-    fn resize(&mut self, _time: f64, _size: (u16, u16)) -> io::Result<()> {
+    fn resize(&mut self, _time: u64, _size: (u16, u16)) -> io::Result<()> {
         Ok(())
     }
 }

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -21,9 +21,9 @@ pub struct Recorder {
 }
 
 enum Message {
-    Output(f64, Vec<u8>),
-    Input(f64, Vec<u8>),
-    Resize(f64, (u16, u16)),
+    Output(u64, Vec<u8>),
+    Input(u64, Vec<u8>),
+    Resize(u64, (u16, u16)),
 }
 
 struct JoinHandle(Option<thread::JoinHandle<()>>);
@@ -55,8 +55,8 @@ impl Recorder {
         }
     }
 
-    fn elapsed_time(&self) -> f64 {
-        self.start_time.elapsed().as_secs_f64()
+    fn elapsed_time(&self) -> u64 {
+        self.start_time.elapsed().as_micros() as u64
     }
 }
 


### PR DESCRIPTION
In 3.0 `cat`'s primary function will be to concatenate multiple asciicast files, adjusting the timestamps accordingly, printing the output asciicast file to stdout.