### PR TITLE
Accept ISO-8859-1 as a locale

### DIFF
--- a/asciinema/__main__.py
+++ b/asciinema/__main__.py
@@ -24,7 +24,7 @@ def valid_encoding() -> bool:
     if loc is None:
         return False
     else:
-        return loc.upper() in ("US-ASCII", "UTF-8", "UTF8")
+        return loc.upper() in ("ISO-8859-1", "US-ASCII", "UTF-8", "UTF8")
 
 
 def positive_int(value: str) -> int:


### PR DESCRIPTION
I was unable to get locale.nl_langinfo to print 'US-ASCII', however, in my testing on Linux, most combinations of LC_{CTYPE,*}=en_US returned 'ISO-8859-1'.

**Note about the supposed Rust rewrite**:  Even though the rewrite in Rust has yet to manifest its source code publicly, much less officially release, in keeping with spirit of the GPL, I still wish to share my changes back upstream.