### PR TITLE
Add `convert` command

### DIFF
--- a/src/asciicast/v2.rs
+++ b/src/asciicast/v2.rs
@@ -195,6 +195,10 @@ impl serde::Serialize for V2Header {
 
         let mut len = 4;
 
+        if self.timestamp.is_some() {
+            len += 1;
+        }
+
         if self.idle_time_limit.is_some() {
             len += 1;
         }
@@ -215,7 +219,10 @@ impl serde::Serialize for V2Header {
         map.serialize_entry("version", &2)?;
         map.serialize_entry("width", &self.width)?;
         map.serialize_entry("height", &self.height)?;
-        map.serialize_entry("timestamp", &self.timestamp)?;
+
+        if let Some(timestamp) = self.timestamp {
+            map.serialize_entry("timestamp", &timestamp)?;
+        }
 
         if let Some(limit) = self.idle_time_limit {
             map.serialize_entry("idle_time_limit", &limit)?;

--- a/src/cmd/convert.rs
+++ b/src/cmd/convert.rs
@@ -1,0 +1,98 @@
+use crate::asciicast::{self, Header};
+use crate::encoder;
+use crate::util;
+use anyhow::{bail, Result};
+use clap::{Args, ValueEnum};
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug, Args)]
+pub struct Cli {
+    #[arg(value_name = "INPUT_FILENAME_OR_URL")]
+    input_filename: String,
+
+    output_filename: String,
+
+    /// Output file format [default: asciicast]
+    #[arg(short, long, value_enum)]
+    format: Option<Format>,
+
+    /// Overwrite target file if it already exists
+    #[arg(long)]
+    overwrite: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum Format {
+    Asciicast,
+    Raw,
+    Txt,
+}
+
+use crate::encoder::EncoderExt;
+
+impl Cli {
+    pub fn run(self) -> Result<()> {
+        let path = util::get_local_path(&self.input_filename)?;
+        let input = asciicast::open_from_path(&path)?;
+        let mut output = self.get_output(&input.header)?;
+
+        output.encode(input)
+    }
+
+    fn get_output(&self, header: &Header) -> Result<Box<dyn encoder::Encoder>> {
+        let file = self.open_file()?;
+
+        let format = self.format.unwrap_or_else(|| {
+            if self.output_filename.to_lowercase().ends_with(".txt") {
+                Format::Txt
+            } else {
+                Format::Asciicast
+            }
+        });
+
+        match format {
+            Format::Asciicast => Ok(Box::new(encoder::AsciicastEncoder::new(
+                file,
+                false,
+                0,
+                header.into(),
+            ))),
+
+            Format::Raw => Ok(Box::new(encoder::RawEncoder::new(file, false))),
+            Format::Txt => Ok(Box::new(encoder::TxtEncoder::new(file))),
+        }
+    }
+
+    fn open_file(&self) -> Result<fs::File> {
+        let overwrite = self.get_mode()?;
+
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .create(overwrite)
+            .create_new(!overwrite)
+            .truncate(overwrite)
+            .open(&self.output_filename)?;
+
+        Ok(file)
+    }
+
+    fn get_mode(&self) -> Result<bool> {
+        let mut overwrite = self.overwrite;
+        let path = Path::new(&self.output_filename);
+
+        if path.exists() {
+            let metadata = fs::metadata(path)?;
+
+            if metadata.len() == 0 {
+                overwrite = true;
+            }
+
+            if !overwrite {
+                bail!("file exists, use --overwrite option to overwrite the file");
+            }
+        }
+
+        Ok(overwrite)
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod cat;
+pub mod convert;
 pub mod play;
 pub mod rec;
 pub mod upload;

--- a/src/encoder/asciicast.rs
+++ b/src/encoder/asciicast.rs
@@ -60,3 +60,14 @@ where
         self.writer.write_event(event)
     }
 }
+
+impl From<&Header> for Metadata {
+    fn from(header: &Header) -> Self {
+        Metadata {
+            idle_time_limit: header.idle_time_limit.as_ref().cloned(),
+            command: header.command.as_ref().cloned(),
+            title: header.title.as_ref().cloned(),
+            env: header.env.as_ref().cloned(),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,9 @@ enum Commands {
     /// Concatenate multiple recordings
     Cat(cmd::cat::Cli),
 
+    /// Convert a recording into another format
+    Convert(cmd::convert::Cli),
+
     /// Upload a recording to an asciinema server
     Upload(cmd::upload::Cli),
 
@@ -53,6 +56,7 @@ fn main() -> Result<()> {
         Commands::Rec(record) => record.run(&config),
         Commands::Play(play) => play.run(&config),
         Commands::Cat(cat) => cat.run(),
+        Commands::Convert(convert) => convert.run(),
         Commands::Upload(upload) => upload.run(&config),
         Commands::Auth(auth) => auth.run(&config),
     }


### PR DESCRIPTION
```
$ asciinema convert -h

Convert a recording into another format

Usage: asciinema convert [OPTIONS] <INPUT_FILENAME_OR_URL> <OUTPUT_FILENAME>

Arguments:
  <INPUT_FILENAME_OR_URL>
  <OUTPUT_FILENAME>

Options:
  -f, --format <FORMAT>  Output file format [default: asciicast] [possible values: asciicast, raw, txt]
      --overwrite        Overwrite target file if it already exists
```

This provides conversion from asciicast (v1 and v2) into asciicast v2, raw output, or plain text log.

When output filename has `.txt` extension then text output is assumed (unless `--format` option given).

Examples:

```
# convert asciicast v1 to v2
asciinema convert demo.json demo.cast

# convert asciicast to plain text log
asciinema convert demo.cast demo.txt 

# convert asciicast to raw output
asciinema convert demo.cast demo.raw -f raw 

# convert asciicast from URL to plain text log
asciinema convert https://asciinema.org/a/Ry4cnZr5VHFIBRbmk9XBld5To demo.txt 
```