### PR TITLE
Logging for the `stream` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +115,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tower-http",
+ "tracing-subscriber",
  "uuid",
  "which",
 ]
@@ -1022,6 +1032,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1143,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1192,12 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -1476,6 +1511,50 @@ checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
 dependencies = [
  "redox_syscall 0.2.16",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.4",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
@@ -1830,6 +1909,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2117,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,6 +2258,7 @@ dependencies = [
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2192,6 +2291,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2304,6 +2433,12 @@ checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom 0.2.10",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tower-http",
+ "tracing",
  "tracing-subscriber",
  "uuid",
  "which",
@@ -2281,7 +2282,19 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,5 @@ futures-util = "0.3.30"
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 rust-embed = "8.2.0"
 mime_guess = "2.0.4"
-tower-http = "0.5.1"
+tower-http = { version = "0.5.1", features = ["trace"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,5 @@ tokio-stream = { version = "0.1.14", features = ["sync"] }
 rust-embed = "8.2.0"
 mime_guess = "2.0.4"
 tower-http = { version = "0.5.1", features = ["trace"] }
+tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/src/cmd/stream.rs
+++ b/src/cmd/stream.rs
@@ -94,6 +94,7 @@ impl Cli {
                 .map_err(|e| anyhow!("cannot open log file {}: {}", path.to_string_lossy(), e))?;
 
             tracing_subscriber::fmt()
+                .with_ansi(false)
                 .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
                 .with_writer(file)
                 .init();

--- a/src/cmd/stream.rs
+++ b/src/cmd/stream.rs
@@ -64,7 +64,7 @@ impl Cli {
                 Box::new(tty::NullTty::open()?)
             };
 
-            self.init_logging()?;
+            self.init_logging(config)?;
 
             pty::exec(
                 &exec_command,
@@ -87,8 +87,14 @@ impl Cli {
             .or(config.cmd_stream_command())
     }
 
-    fn init_logging(&self) -> Result<()> {
-        if let Some(path) = self.log_file.as_ref() {
+    fn init_logging(&self, config: &Config) -> Result<()> {
+        let log_file = self
+            .log_file
+            .as_ref()
+            .cloned()
+            .or(config.cmd_stream_log_file());
+
+        if let Some(path) = &log_file {
             let file = fs::OpenOptions::new()
                 .create(true)
                 .append(true)

--- a/src/cmd/stream.rs
+++ b/src/cmd/stream.rs
@@ -9,6 +9,8 @@ use clap::Args;
 use std::fs;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Args)]
 pub struct Cli {
@@ -93,9 +95,13 @@ impl Cli {
                 .open(path)
                 .map_err(|e| anyhow!("cannot open log file {}: {}", path.to_string_lossy(), e))?;
 
+            let filter = EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy();
+
             tracing_subscriber::fmt()
                 .with_ansi(false)
-                .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+                .with_env_filter(filter)
                 .with_writer(file)
                 .init();
         }

--- a/src/cmd/stream.rs
+++ b/src/cmd/stream.rs
@@ -20,7 +20,7 @@ pub struct Cli {
     #[arg(short, long)]
     command: Option<String>,
 
-    /// HTTP listen address
+    /// HTTP server listen address
     #[clap(short, long, default_value = "127.0.0.1:8080")]
     listen_addr: SocketAddr,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,7 @@ pub struct Stream {
     pub env: Option<String>,
     pub prefix_key: Option<String>,
     pub pause_key: Option<String>,
+    pub log_file: Option<PathBuf>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -212,6 +213,10 @@ impl Config {
             .as_ref()
             .map(parse_key)
             .transpose()
+    }
+
+    pub fn cmd_stream_log_file(&self) -> Option<PathBuf> {
+        self.cmd.stream.log_file.as_ref().cloned()
     }
 }
 

--- a/src/streamer/mod.rs
+++ b/src/streamer/mod.rs
@@ -11,6 +11,7 @@ use std::net::{self, TcpListener};
 use std::thread;
 use std::time::Instant;
 use tokio::sync::{mpsc, oneshot};
+use tracing::info;
 
 pub struct Streamer {
     record_input: bool,
@@ -66,8 +67,11 @@ impl Streamer {
     }
 
     fn notify<S: ToString>(&self, message: S) {
+        let message = message.to_string();
+        info!(message);
+
         self.notifier_tx
-            .send(message.to_string())
+            .send(message)
             .expect("notification send should succeed");
     }
 }

--- a/src/streamer/mod.rs
+++ b/src/streamer/mod.rs
@@ -190,6 +190,7 @@ async fn event_loop(
                 match client {
                     Some(client) => {
                         client.accept(session.subscribe());
+                        info!("viewer count: {}", session.subscriber_count());
                     }
 
                     None => break,

--- a/src/streamer/session.rs
+++ b/src/streamer/session.rs
@@ -69,6 +69,10 @@ impl Session {
         Subscription { init, broadcast_rx }
     }
 
+    pub fn subscriber_count(&self) -> usize {
+        self.broadcast_tx.receiver_count()
+    }
+
     fn elapsed_time(&self) -> u64 {
         self.stream_time + self.last_event_time.elapsed().as_micros() as u64
     }


### PR DESCRIPTION
This adds logging for the streamer (`asciinema stream` command).

Disabled by default.

Can be enabled by specifying a log file via `--log-file` option to `stream` command:

```
asciinema stream --log-file stream.log
```

Alternatively, it can be set permanently in the config file (`~/.config/asciinema/config.toml`):

```toml
[cmd.stream]
log_file = "/tmp/asciinema-stream.log"
```