### PR TITLE
Capture terminal color palette

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "mime_guess",
  "nix",
  "reqwest",
+ "rgb",
  "rust-embed",
  "rustyline",
  "scraper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ mime_guess = "2.0.4"
 tower-http = { version = "0.5.1", features = ["trace"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+rgb = "0.8.37"

--- a/src/asciicast/v1.rs
+++ b/src/asciicast/v1.rs
@@ -38,6 +38,7 @@ pub fn load(json: String) -> Result<Asciicast<'static>> {
         command: asciicast.command.clone(),
         title: asciicast.title.clone(),
         env: asciicast.env.clone(),
+        theme: None,
     };
 
     let events = Box::new(

--- a/src/encoder/asciicast.rs
+++ b/src/encoder/asciicast.rs
@@ -14,6 +14,7 @@ pub struct Metadata {
     pub command: Option<String>,
     pub title: Option<String>,
     pub env: Option<HashMap<String, String>>,
+    pub theme: Option<tty::Theme>,
 }
 
 impl<W> AsciicastEncoder<W>
@@ -38,6 +39,7 @@ where
             command: self.metadata.command.clone(),
             title: self.metadata.title.clone(),
             env: self.metadata.env.clone(),
+            theme: self.metadata.theme.clone(),
         }
     }
 }
@@ -68,6 +70,7 @@ impl From<&Header> for Metadata {
             command: header.command.as_ref().cloned(),
             title: header.title.as_ref().cloned(),
             env: header.env.as_ref().cloned(),
+            theme: header.theme.as_ref().cloned(),
         }
     }
 }

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -1,9 +1,17 @@
 use anyhow::Result;
-use nix::{libc, pty, unistd};
-use std::{
-    fs, io,
-    os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd},
+use nix::{
+    errno::Errno,
+    libc, pty,
+    sys::{
+        select::{select, FdSet},
+        time::TimeVal,
+    },
+    unistd,
 };
+use rgb::RGB8;
+use std::fs;
+use std::io;
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
 use termion::raw::{IntoRawMode, RawTerminal};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -23,6 +31,14 @@ impl From<TtySize> for (u16, u16) {
 
 pub trait Tty: io::Write + io::Read + AsFd {
     fn get_size(&self) -> pty::Winsize;
+    fn get_theme(&self) -> Option<Theme>;
+}
+
+#[derive(Clone)]
+pub struct Theme {
+    pub fg: RGB8,
+    pub bg: RGB8,
+    pub palette: Vec<RGB8>,
 }
 
 pub struct DevTty {
@@ -43,6 +59,25 @@ impl DevTty {
     }
 }
 
+fn parse_color(rgb: &str) -> Option<RGB8> {
+    let mut components = rgb.split('/');
+    let r_hex = components.next()?;
+    let g_hex = components.next()?;
+    let b_hex = components.next()?;
+
+    if r_hex.len() < 2 || g_hex.len() < 2 || b_hex.len() < 2 {
+        return None;
+    }
+
+    let r = u8::from_str_radix(&r_hex[..2], 16).ok()?;
+    let g = u8::from_str_radix(&g_hex[..2], 16).ok()?;
+    let b = u8::from_str_radix(&b_hex[..2], 16).ok()?;
+
+    Some(RGB8::new(r, g, b))
+}
+
+static COLORS_QUERY: &[u8; 148] = b"\x1b]10;?\x07\x1b]11;?\x07\x1b]4;0;?\x07\x1b]4;1;?\x07\x1b]4;2;?\x07\x1b]4;3;?\x07\x1b]4;4;?\x07\x1b]4;5;?\x07\x1b]4;6;?\x07\x1b]4;7;?\x07\x1b]4;8;?\x07\x1b]4;9;?\x07\x1b]4;10;?\x07\x1b]4;11;?\x07\x1b]4;12;?\x07\x1b]4;13;?\x07\x1b]4;14;?\x07\x1b]4;15;?\x07";
+
 impl Tty for DevTty {
     fn get_size(&self) -> pty::Winsize {
         let mut winsize = pty::Winsize {
@@ -55,6 +90,74 @@ impl Tty for DevTty {
         unsafe { libc::ioctl(self.file.as_raw_fd(), libc::TIOCGWINSZ, &mut winsize) };
 
         winsize
+    }
+
+    fn get_theme(&self) -> Option<Theme> {
+        let mut query = &COLORS_QUERY[..];
+        let mut response = Vec::new();
+        let mut buf = [0u8; 1024];
+        let mut color_count = 0;
+        let fd = self.as_fd().as_raw_fd();
+
+        loop {
+            let mut timeout = TimeVal::new(0, 50_000);
+            let mut rfds = FdSet::new();
+            let mut wfds = FdSet::new();
+            rfds.insert(self);
+
+            if !query.is_empty() {
+                wfds.insert(self);
+            }
+
+            match select(None, &mut rfds, &mut wfds, None, &mut timeout) {
+                Ok(0) => return None,
+
+                Ok(_) => {
+                    if rfds.contains(self) {
+                        let n = unistd::read(fd, &mut buf).ok()?;
+                        response.extend_from_slice(&buf[..n]);
+
+                        color_count += &buf[..n]
+                            .iter()
+                            .filter(|b| *b == &0x07 || *b == &b'\\')
+                            .count();
+
+                        if color_count == 18 {
+                            break;
+                        }
+                    }
+
+                    if wfds.contains(self) {
+                        let n = unistd::write(fd, query).ok()?;
+                        query = &query[n..];
+                    }
+                }
+
+                Err(e) => {
+                    if e == Errno::EINTR {
+                        continue;
+                    } else {
+                        return None;
+                    }
+                }
+            }
+        }
+
+        let response = String::from_utf8_lossy(response.as_slice());
+        let mut colors = response.match_indices("rgb:");
+        let (idx, _) = colors.next()?;
+        let fg = parse_color(&response[idx + 4..])?;
+        let (idx, _) = colors.next()?;
+        let bg = parse_color(&response[idx + 4..])?;
+        let mut palette = Vec::new();
+
+        for _ in 0..16 {
+            let (idx, _) = colors.next()?;
+            let color = parse_color(&response[idx + 4..])?;
+            palette.push(color);
+        }
+
+        Some(Theme { fg, bg, palette })
     }
 }
 
@@ -104,6 +207,10 @@ impl Tty for NullTty {
             ws_ypixel: 0,
         }
     }
+
+    fn get_theme(&self) -> Option<Theme> {
+        None
+    }
 }
 
 impl io::Read for NullTty {
@@ -125,5 +232,35 @@ impl io::Write for NullTty {
 impl AsFd for NullTty {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.tx.as_fd()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rgb::RGB8;
+
+    #[test]
+    fn parse_color() {
+        use super::parse_color as parse;
+        let color = Some(RGB8::new(0xaa, 0xbb, 0xcc));
+
+        assert_eq!(parse("aa11/bb22/cc33"), color);
+        assert_eq!(parse("aa11/bb22/cc33\x07"), color);
+        assert_eq!(parse("aa11/bb22/cc33\x1b\\"), color);
+        assert_eq!(parse("aa11/bb22/cc33.."), color);
+        assert_eq!(parse("aa1/bb2/cc3"), color);
+        assert_eq!(parse("aa1/bb2/cc3\x07"), color);
+        assert_eq!(parse("aa1/bb2/cc3\x1b\\"), color);
+        assert_eq!(parse("aa1/bb2/cc3.."), color);
+        assert_eq!(parse("aa/bb/cc"), color);
+        assert_eq!(parse("aa/bb/cc\x07"), color);
+        assert_eq!(parse("aa/bb/cc\x1b\\"), color);
+        assert_eq!(parse("aa/bb/cc.."), color);
+        assert_eq!(parse("aa11/bb22"), None);
+        assert_eq!(parse("xxxx/yyyy/zzzz"), None);
+        assert_eq!(parse("xxx/yyy/zzz"), None);
+        assert_eq!(parse("xx/yy/zz"), None);
+        assert_eq!(parse("foo"), None);
+        assert_eq!(parse(""), None);
     }
 }

--- a/tests/casts/full.cast
+++ b/tests/casts/full.cast
@@ -1,0 +1,6 @@
+{"version":2,"width":100,"height":50,"command":"/bin/bash","env":{"TERM":"xterm-256color","SHELL":"/bin/bash"},"theme":{"fg":"#000000","bg":"#ffffff","palette":"#241f31:#c01c28:#2ec27e:#f5c211:#1e78e4:#9841bb:#0ab9dc:#c0bfbc:#5e5c64:#ed333b:#57e389:#f8e45c:#51a1ff:#c061cb:#4fd2fd:#f6f5f4"}}
+[0.000001, "o", "ż"]
+[1.0, "o", "ółć"]
+[2.3, "i", "\n"]
+[5.600001, "r", "80x40"]
+[10.5, "o", "\r\n"]

--- a/tests/casts/minimal.cast
+++ b/tests/casts/minimal.cast
@@ -1,0 +1,2 @@
+{"version":2,"width":100,"height":50}
+[1.23, "o", "hello"]


### PR DESCRIPTION
This uses OSC sequence to query the colors from the terminal, and saves them as a theme in asciicast v2 header
(https://docs.asciinema.org/manual/asciicast/v2/#theme).