### PR TITLE
Added note in build section of readme explaining that windows is not supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ This produces the binary in _release mode_ (`--release`) at
 `target/release/asciinema`. There are no other build artifacts so you can just
 copy the binary to a directory in your `$PATH`.
 
+> [!NOTE]
+> Windows is currently not supported. _(See [#467](https://github.com/asciinema/asciinema/issues/467))_
+
 ## Development
 
 This branch contains the next generation of the asciinema CLI, written in Rust


### PR DESCRIPTION
Simple note stating:

> [!NOTE]
> Windows is currently not supported. _(See [#467](https://github.com/asciinema/discussions/issues/277))_

closes asciinema/asciinema#615