### PR TITLE
add upload-rust-binary-action to upload build results

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          # (optional) Path to changelog.
+          changelog: CHANGELOG.md
+          # (required) GitHub token for creating GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
+    needs: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
+          # Note that glob pattern is not supported yet.
+          bin: asciinema
+          # (required) GitHub token for uploading assets to GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # asciinema changelog
 
+## 0.0.1-alpha
+
+* test github-action build
+
 ## 3.0.0 (wip)
 
 * Full rewrite in Rust


### PR DESCRIPTION
It's so great to see asciinema switch to Rust.
static binary is much easy to install.

Do you consider to enable upload-rust-binary-action to upload build release?

I just copy the example from https://github.com/taiki-e/upload-rust-binary-action
It supports cross-build.

Currently we just can cargo install.
```
cargo install --git https://github.com/asciinema/asciinema ## still need local build
```

I wish cargo binstall could work. https://github.com/cargo-bins/cargo-binstall
```
cargo binstall asciinema ## directly download binaries. 
```

Here is my test build action: https://github.com/shawn111/asciinema/actions/runs/7950061837

Release binares:
https://github.com/shawn111/asciinema/releases/download/v0.0.1-alpha/asciinema-x86_64-unknown-linux-gnu.tar.gz