### PR TITLE
Stream forwarder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,11 @@ dependencies = [
  "termion",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "which",
 ]
@@ -930,9 +932,9 @@ dependencies = [
  "futures-util",
  "http 0.2.11",
  "hyper 0.14.28",
- "rustls",
+ "rustls 0.21.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -1595,7 +1597,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.10",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1603,14 +1605,14 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -1717,8 +1719,22 @@ checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1731,12 +1747,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868e20fada228fefaf6b652e00cc73623d54f8171e7352c18bb281571f2d92da"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2036,6 +2069,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,7 +2248,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.3",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -2233,8 +2283,12 @@ checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.22.3",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.25.0",
  "tungstenite",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -2411,6 +2465,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls 0.22.3",
+ "rustls-pki-types",
  "sha1",
  "thiserror",
  "url",
@@ -2629,6 +2685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "which"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,3 +2887,9 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
+ "sha2",
  "signal-hook",
  "tempfile",
  "termion",
@@ -1627,16 +1628,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom 0.2.12",
  "libc",
  "spin",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 rgb = "0.8.37"
 url = "2.5.0"
 tokio-tungstenite = { version = "0.21.0", features = ["rustls-tls-webpki-roots"] }
+sha2 = "0.10.8"
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ tower-http = { version = "0.5.1", features = ["trace"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 rgb = "0.8.37"
+url = "2.5.0"
+tokio-tungstenite = { version = "0.21.0", features = ["rustls-tls-webpki-roots"] }
 
 [profile.release]
 strip = true

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -26,10 +26,14 @@ fn build_exec_command(command: Option<String>) -> Vec<String> {
     vec!["/bin/sh".to_owned(), "-c".to_owned(), command]
 }
 
-fn build_exec_extra_env() -> HashMap<String, String> {
+fn build_exec_extra_env(vars: &[(String, String)]) -> HashMap<String, String> {
     let mut env = HashMap::new();
 
     env.insert("ASCIINEMA_REC".to_owned(), "1".to_owned());
+
+    for (k, v) in vars {
+        env.insert(k.clone(), v.clone());
+    }
 
     env
 }

--- a/src/cmd/rec.rs
+++ b/src/cmd/rec.rs
@@ -83,7 +83,7 @@ impl Cli {
         let notifier = super::get_notifier(config);
         let record_input = self.input || config.cmd_rec_input();
         let exec_command = super::build_exec_command(command.as_ref().cloned());
-        let exec_extra_env = super::build_exec_extra_env();
+        let exec_extra_env = super::build_exec_extra_env(&[]);
 
         logger::info!("Recording session started, writing to {}", self.filename);
 

--- a/src/streamer/forwarder.rs
+++ b/src/streamer/forwarder.rs
@@ -1,0 +1,103 @@
+use super::alis;
+use super::session;
+use futures_util::Sink;
+use futures_util::{sink, SinkExt, Stream, StreamExt};
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+use tokio_stream::wrappers::IntervalStream;
+use tokio_tungstenite::tungstenite;
+use tokio_tungstenite::tungstenite::Message;
+use tracing::{debug, info};
+
+const WS_PING_INTERVAL: u64 = 15;
+const MAX_RECONNECT_DELAY: u64 = 5000;
+
+pub async fn forward(
+    clients_tx: mpsc::Sender<session::Client>,
+    url: url::Url,
+) -> anyhow::Result<()> {
+    let mut reconnect_attempt = 0;
+
+    info!("forwarding to {url}");
+
+    loop {
+        let time = Instant::now();
+
+        match forward_once(&clients_tx, &url).await {
+            Ok(_) => return Ok(()),
+            Err(e) => debug!("{e:?}"),
+        }
+
+        if time.elapsed().as_secs_f32() > 1.0 {
+            reconnect_attempt = 0;
+        }
+
+        let delay = exponential_delay(reconnect_attempt);
+        reconnect_attempt = (reconnect_attempt + 1).min(10);
+        info!("connection closed, reconnecting in {delay}");
+        tokio::time::sleep(Duration::from_millis(delay)).await;
+    }
+}
+
+async fn forward_once(
+    clients_tx: &mpsc::Sender<session::Client>,
+    url: &url::Url,
+) -> anyhow::Result<()> {
+    let (ws, _) = tokio_tungstenite::connect_async(url).await?;
+    info!("connected to the endpoint");
+    let (sink, stream) = ws.split();
+    let drainer = tokio::spawn(stream.map(Ok).forward(sink::drain()));
+    let events = alis::stream(clients_tx).await?.map(ws_result);
+    let result = forward_with_pings(events, sink).await;
+    drainer.abort();
+
+    result
+}
+
+async fn forward_with_pings<T, U>(events: T, mut sink: U) -> anyhow::Result<()>
+where
+    T: Stream<Item = anyhow::Result<Message>> + Unpin,
+    U: Sink<Message> + Unpin,
+    <U>::Error: Into<anyhow::Error>,
+{
+    let mut events = events.fuse();
+    let mut pings = ping_stream().fuse();
+
+    loop {
+        futures_util::select! {
+            event = events.next() => {
+                match event {
+                    Some(event) => {
+                        sink.send(event?).await.map_err(|e| e.into())?;
+                    }
+
+                    None => return Ok(())
+                }
+            },
+
+            ping = pings.next() => {
+                sink.send(ping.unwrap()).await.map_err(|e| e.into())?;
+            }
+        }
+    }
+}
+
+fn exponential_delay(attempt: usize) -> u64 {
+    (2_u64.pow(attempt as u32) * 500).min(MAX_RECONNECT_DELAY)
+}
+
+fn ws_result(m: Result<Vec<u8>, BroadcastStreamRecvError>) -> anyhow::Result<tungstenite::Message> {
+    match m {
+        Ok(bytes) => Ok(tungstenite::Message::binary(bytes)),
+        Err(e) => Err(anyhow::anyhow!(e)),
+    }
+}
+
+fn ping_stream() -> impl Stream<Item = tungstenite::Message> {
+    let interval = tokio::time::interval(Duration::from_secs(WS_PING_INTERVAL));
+
+    IntervalStream::new(interval)
+        .skip(1)
+        .map(|_| tungstenite::Message::Ping(vec![]))
+}

--- a/src/streamer/mod.rs
+++ b/src/streamer/mod.rs
@@ -91,15 +91,13 @@ impl pty::Recorder for Streamer {
         let (shutdown_tx, _shutdown_rx) = broadcast::channel::<()>(1);
         let runtime = build_tokio_runtime();
 
-        let server = match self.listener.take() {
-            Some(listener) => Some(runtime.spawn(server::serve(
+        let server = self.listener.take().map(|listener| {
+            runtime.spawn(server::serve(
                 listener,
                 clients_tx.clone(),
                 shutdown_tx.subscribe(),
-            ))),
-
-            None => None,
-        };
+            ))
+        });
 
         let forwarder = self
             .forward_url

--- a/src/streamer/mod.rs
+++ b/src/streamer/mod.rs
@@ -223,7 +223,7 @@ async fn event_loop(
                 match client {
                     Some(client) => {
                         client.accept(session.subscribe());
-                        info!("viewer count: {}", session.subscriber_count());
+                        info!("client count: {}", session.subscriber_count());
                     }
 
                     None => break,

--- a/src/streamer/mod.rs
+++ b/src/streamer/mod.rs
@@ -10,6 +10,7 @@ use crate::util;
 use std::io;
 use std::net::{self, TcpListener};
 use std::thread;
+use std::time::Duration;
 use std::time::Instant;
 use tokio::sync::{broadcast, mpsc};
 use tracing::info;
@@ -108,10 +109,10 @@ impl pty::Recorder for Streamer {
             runtime.block_on(async move {
                 event_loop(pty_rx, &mut clients_rx, tty_size, theme).await;
                 let _ = shutdown_tx.send(());
-                let _ = server.await;
+                let _ = tokio::time::timeout(Duration::from_secs(5), server).await;
 
                 if let Some(task) = forwarder {
-                    let _ = task.await;
+                    let _ = tokio::time::timeout(Duration::from_secs(5), task).await;
                 }
 
                 let _ = clients_rx.recv().await;

--- a/src/streamer/mod.rs
+++ b/src/streamer/mod.rs
@@ -102,7 +102,7 @@ impl pty::Recorder for Streamer {
         let forwarder = self
             .forward_url
             .take()
-            .map(|url| runtime.spawn(forwarder::forward(clients_tx, url, shutdown_tx.subscribe())));
+            .map(|url| runtime.spawn(forwarder::forward(url, clients_tx, shutdown_tx.subscribe())));
 
         let theme = self.theme.take();
 
@@ -143,7 +143,7 @@ impl pty::Recorder for Streamer {
         }
 
         let event = Event::Output(self.elapsed_time(), raw.into());
-        self.pty_tx.send(event).expect("output send should succeed");
+        let _ = self.pty_tx.send(event);
     }
 
     fn input(&mut self, raw: &[u8]) -> bool {
@@ -173,7 +173,7 @@ impl pty::Recorder for Streamer {
 
         if self.record_input && !self.paused {
             let event = Event::Input(self.elapsed_time(), raw.into());
-            self.pty_tx.send(event).expect("input send should succeed");
+            let _ = self.pty_tx.send(event);
         }
 
         true
@@ -181,7 +181,7 @@ impl pty::Recorder for Streamer {
 
     fn resize(&mut self, size: crate::tty::TtySize) {
         let event = Event::Resize(self.elapsed_time(), size);
-        self.pty_tx.send(event).expect("resize send should succeed");
+        let _ = self.pty_tx.send(event);
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, bail, Result};
 use reqwest::Url;
+use sha2::Digest;
 use std::path::{Path, PathBuf};
 use std::{io, thread};
 use tempfile::NamedTempFile;
@@ -113,6 +114,18 @@ impl Utf8Decoder {
 
         output
     }
+}
+
+pub fn sha2_digest(s: &str) -> String {
+    let mut hasher = sha2::Sha224::new();
+    hasher.update(s.as_bytes());
+
+    hasher
+        .finalize()
+        .as_slice()
+        .iter()
+        .map(|byte| format!("{:02x}", byte))
+        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This implements stream forwarding (to asciinema server) for `asciinema stream` command.

- `asciinema stream -r` - relay the stream to user's default server stream
- `asciinema stream -r <ID>` - relay the stream to user's specific server stream
- `asciinema stream -r -s` - both relay and serve the stream locally

---

TODO:

- [x] - is `-l` / `--listen` best name? rename to `-s` / `--serve`?
- [x] - is `-f` / `--forward` best name? rename to `-r` / `--relay`?
- [ ] - is `--tty-size` best name? rename to `-w` / `--winsize`?