### PR TITLE
feat: Make asciinema work with shebangs

### DIFF
--- a/src/asciicast.rs
+++ b/src/asciicast.rs
@@ -49,7 +49,11 @@ pub fn open_from_path<S: AsRef<Path>>(path: S) -> Result<Asciicast<'static>> {
 
 pub fn open<'a, R: BufRead + 'a>(reader: R) -> Result<Asciicast<'a>> {
     let mut lines = reader.lines();
-    let first_line = lines.next().ok_or(anyhow!("empty file"))??;
+    let mut first_line = lines.next().ok_or(anyhow!("empty file"))??;
+
+    if first_line.starts_with("#!") {
+        first_line = lines.next().ok_or(anyhow!("empty file"))??;
+    }
 
     if let Ok(parser) = v2::open(&first_line) {
         Ok(parser.parse(lines))

--- a/src/asciicast/v2.rs
+++ b/src/asciicast/v2.rs
@@ -173,7 +173,7 @@ where
 
     pub fn write_header(&mut self, header: &Header) -> io::Result<()> {
         let header: V2Header = header.into();
-
+        writeln!(self.writer, "{}", "#!/usr/bin/env -S asciinema play")?;
         writeln!(self.writer, "{}", serde_json::to_string(&header)?)
     }
 


### PR DESCRIPTION
I would like to explore the idea of having asciinema working with shebangs, thus having asciicasts work by uttering:
```bash
./file.cast
```

I wanted to have some example code, in order to start the discussion.

The file would have to be made executable after it is created. I think this should be an argument to `asciinema rec`, something like `-e -- make executable cast`.

I think supporting arguments like `-s speed` and the rest is technically doable, but may require some command-line magic and maybe some changes to `asciinema play`, or even an entire new `play` mode.