### PR TITLE
Ref/flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,20 +9,6 @@
   darwin,
   python3,
 }: let
-  testDeps = [
-    python3
-  ];
-
-  buildDeps = rust:
-    [
-      rust
-    ]
-    ++ (lib.optionals stdenv.isDarwin [
-      libiconv
-      darwin.apple_sdk.frameworks.Foundation
-    ])
-    ++ testDeps;
-
   mkPackage = rust:
     (makeRustPlatform {
       cargo = rust;
@@ -31,12 +17,22 @@
     .buildRustPackage {
       pname = packageToml.name;
       inherit (packageToml) version;
+
       src = builtins.path {
         path = ./.;
         inherit (packageToml) name;
       };
+
+			dontUseCargoParallelTests = true;
+
       cargoLock.lockFile = ./Cargo.lock;
-      buildInputs = buildDeps rust;
-      dontUseCargoParallelTests = true;
+
+			nativeBuildInputs = [ rust ];
+			buildInputs = (lib.optional stdenv.isDarwin [
+						libiconv
+						darwin.apple_sdk.frameworks.Foundation
+				]);
+
+			nativeCheckInputs = [python3];
     };
 in (mkPackage rust-bin.stable.latest.minimal)

--- a/default.nix
+++ b/default.nix
@@ -1,38 +1,35 @@
 {
   lib,
   stdenv,
-  rust-bin, # From overlay
+  rust,
   makeRustPlatform,
   packageToml,
-  rust,
   libiconv,
   darwin,
   python3,
-}: let
-  mkPackage = rust:
-    (makeRustPlatform {
-      cargo = rust;
-      rustc = rust;
-    })
-    .buildRustPackage {
-      pname = packageToml.name;
-      inherit (packageToml) version;
+}:
+(makeRustPlatform {
+  cargo = rust;
+  rustc = rust;
+})
+.buildRustPackage {
+  pname = packageToml.name;
+  inherit (packageToml) version;
 
-      src = builtins.path {
-        path = ./.;
-        inherit (packageToml) name;
-      };
+  src = builtins.path {
+    path = ./.;
+    inherit (packageToml) name;
+  };
 
-			dontUseCargoParallelTests = true;
+  dontUseCargoParallelTests = true;
 
-      cargoLock.lockFile = ./Cargo.lock;
+  cargoLock.lockFile = ./Cargo.lock;
 
-			nativeBuildInputs = [ rust ];
-			buildInputs = (lib.optional stdenv.isDarwin [
-						libiconv
-						darwin.apple_sdk.frameworks.Foundation
-				]);
+  nativeBuildInputs = [rust];
+  buildInputs = lib.optional stdenv.isDarwin [
+    libiconv
+    darwin.apple_sdk.frameworks.Foundation
+  ];
 
-			nativeCheckInputs = [python3];
-    };
-in (mkPackage rust-bin.stable.latest.minimal)
+  nativeCheckInputs = [python3];
+}

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  rust-bin, # From overlay
+  makeRustPlatform,
+  packageToml,
+  rust,
+  libiconv,
+  darwin,
+  python3,
+}: let
+  testDeps = [
+    python3
+  ];
+
+  buildDeps = rust:
+    [
+      rust
+    ]
+    ++ (lib.optionals stdenv.isDarwin [
+      libiconv
+      darwin.apple_sdk.frameworks.Foundation
+    ])
+    ++ testDeps;
+
+  mkPackage = rust:
+    (makeRustPlatform {
+      cargo = rust;
+      rustc = rust;
+    })
+    .buildRustPackage {
+      pname = packageToml.name;
+      inherit (packageToml) version;
+      src = builtins.path {
+        path = ./.;
+        inherit (packageToml) name;
+      };
+      cargoLock.lockFile = ./Cargo.lock;
+      buildInputs = buildDeps rust;
+      dontUseCargoParallelTests = true;
+    };
+in (mkPackage rust-bin.stable.latest.minimal)

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717602782,
-        "narHash": "sha256-pL9jeus5QpX5R+9rsp3hhZ+uplVHscNJh8n8VpqscM0=",
+        "lastModified": 1717786204,
+        "narHash": "sha256-4q0s6m0GUcN7q+Y2DqD27iLvbcd1G50T2lv08kKxkSI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8057b67ebf307f01bdcc8fba94d94f75039d1f6",
+        "rev": "051f920625ab5aabe37c920346e3e69d7d34400e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -18,38 +36,32 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
+    "nixpkgs": {
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "lastModified": 1717602782,
+        "narHash": "sha256-pL9jeus5QpX5R+9rsp3hhZ+uplVHscNJh8n8VpqscM0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e8057b67ebf307f01bdcc8fba94d94f75039d1f6",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1707877513,
-        "narHash": "sha256-sp0w2apswd3wv0sAEF7StOGHkns3XUQaO5erhWFZWXk=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "89653a03e0915e4a872788d10680e7eec92f8600",
-        "type": "github"
+        "lastModified": 1717284937,
+        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       }
     },
     "nixpkgs_2": {
@@ -70,14 +82,14 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
@@ -95,21 +107,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -42,11 +42,11 @@
 
         mkDevShell = rust:
           pkgs.mkShell {
-            nativeBuildInputs = buildDeps (rust.override {
+            packages = buildDeps (rust.override {
               extensions = ["rust-src"];
             });
 
-            RUST_BACKTRACE = 1;
+            env.RUST_BACKTRACE = 1;
           };
 
         mkPackage = rust:
@@ -55,19 +55,20 @@
             rustc = rust;
           })
           .buildRustPackage {
-            inherit (cargoToml.package) name version;
+            pname = cargoToml.package.name;
+            inherit (cargoToml.package) version;
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
-            nativeBuildInputs = buildDeps rust;
+            buildInputs = buildDeps rust;
             dontUseCargoParallelTests = true;
           };
       in {
-      	_module.args = {
-      		pkgs = import inputs.nixpkgs {
-      			inherit system;
-      			overlays = [ (import rust-overlay) ];
-      		};
-      	};
+        _module.args = {
+          pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [(import rust-overlay)];
+          };
+        };
 
         formatter = pkgs.alejandra;
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,20 +23,6 @@
         ...
       }: let
         packageToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package;
-        msrv = packageToml.rust-version;
-
-        mkDevShell = rust:
-          pkgs.mkShell {
-            inputsFrom = [
-              (config.packages.default.override {
-                rust = rust.override {
-                  extensions = ["rust-src"];
-                };
-              })
-            ];
-
-            env.RUST_BACKTRACE = 1;
-          };
       in {
         _module.args = {
           pkgs = import inputs.nixpkgs {
@@ -47,10 +33,7 @@
 
         formatter = pkgs.alejandra;
 
-        devShells = {
-          default = mkDevShell pkgs.rust-bin.stable.latest.default;
-          msrv = mkDevShell pkgs.rust-bin.stable.${msrv}.default;
-        };
+        devShells = pkgs.callPackages ./shell.nix {inherit packageToml self';};
 
         packages.default = pkgs.callPackage ./default.nix {inherit packageToml;};
       };

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,8 @@
         system,
         ...
       }: let
-        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-        msrv = cargoToml.package.rust-version;
+        packageToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package;
+        msrv = packageToml.rust-version;
 
         buildDeps = rust:
           with pkgs;
@@ -55,8 +55,8 @@
             rustc = rust;
           })
           .buildRustPackage {
-            pname = cargoToml.package.name;
-            inherit (cargoToml.package) version;
+            pname = packageToml.name;
+            inherit (packageToml) version;
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
             buildInputs = buildDeps rust;

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,7 @@
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
       perSystem = {
-        config,
         self',
-        inputs',
         pkgs,
         system,
         ...

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,10 @@
           .buildRustPackage {
             pname = packageToml.name;
             inherit (packageToml) version;
-            src = ./.;
+            src = builtins.path {
+              path = ./.;
+              inherit (packageToml) name;
+            };
             cargoLock.lockFile = ./Cargo.lock;
             buildInputs = buildDeps rust;
             dontUseCargoParallelTests = true;

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
       }: let
         packageToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package;
       in {
-				formatter = pkgs.alejandra;
+        formatter = pkgs.alejandra;
 
         _module.args = {
           pkgs = import inputs.nixpkgs {
@@ -33,7 +33,10 @@
 
         devShells = pkgs.callPackages ./shell.nix {inherit packageToml self';};
 
-        packages.default = pkgs.callPackage ./default.nix {inherit packageToml;};
+        packages.default = pkgs.callPackage ./default.nix {
+          inherit packageToml;
+          rust = pkgs.rust-bin.stable.latest.minimal;
+        };
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -22,14 +22,14 @@
       }: let
         packageToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package;
       in {
+				formatter = pkgs.alejandra;
+
         _module.args = {
           pkgs = import inputs.nixpkgs {
             inherit system;
             overlays = [(import rust-overlay)];
           };
         };
-
-        formatter = pkgs.alejandra;
 
         devShells = pkgs.callPackages ./shell.nix {inherit packageToml self';};
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,53 +2,80 @@
   description = "Terminal session recorder";
 
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixpkgs-unstable;
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
     rust-overlay.url = github:oxalica/rust-overlay;
-    flake-utils.url = github:numtide/flake-utils;
+    flake-parts.url = github:hercules-ci/flake-parts;
   };
 
-  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        overlays = [ (import rust-overlay) ];
-        pkgs = import nixpkgs { inherit system overlays; };
+  outputs = inputs @ {
+    flake-parts,
+    rust-overlay,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
+      perSystem = {
+        config,
+        self',
+        inputs',
+        pkgs,
+        system,
+        ...
+      }: let
         cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         msrv = cargoToml.package.rust-version;
 
-        buildDeps = rust: with pkgs; [
-          rust
-        ] ++ (lib.optionals stdenv.isDarwin [
-          libiconv
-          darwin.apple_sdk.frameworks.Foundation
-        ]) ++ testDeps;
+        buildDeps = rust:
+          with pkgs;
+            [
+              rust
+            ]
+            ++ (lib.optionals stdenv.isDarwin [
+              libiconv
+              darwin.apple_sdk.frameworks.Foundation
+            ])
+            ++ testDeps;
 
         testDeps = with pkgs; [
           python3
         ];
 
-        mkDevShell = rust: pkgs.mkShell {
-          nativeBuildInputs = buildDeps (rust.override {
-            extensions = [ "rust-src" ];
-          });
+        mkDevShell = rust:
+          pkgs.mkShell {
+            nativeBuildInputs = buildDeps (rust.override {
+              extensions = ["rust-src"];
+            });
 
-          RUST_BACKTRACE = 1;
-        };
+            RUST_BACKTRACE = 1;
+          };
 
-        mkPackage = rust: (pkgs.makeRustPlatform {
-          cargo = rust;
-          rustc = rust;
-        }).buildRustPackage {
-          inherit (cargoToml.package) name version;
-          src = ./.;
-          cargoLock.lockFile = ./Cargo.lock;
-          nativeBuildInputs = buildDeps rust;
-          dontUseCargoParallelTests = true;
+        mkPackage = rust:
+          (pkgs.makeRustPlatform {
+            cargo = rust;
+            rustc = rust;
+          })
+          .buildRustPackage {
+            inherit (cargoToml.package) name version;
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+            nativeBuildInputs = buildDeps rust;
+            dontUseCargoParallelTests = true;
+          };
+      in {
+      	_module.args = {
+      		pkgs = import inputs.nixpkgs {
+      			inherit system;
+      			overlays = [ (import rust-overlay) ];
+      		};
+      	};
+
+        formatter = pkgs.alejandra;
+
+        devShells = {
+          default = mkDevShell pkgs.rust-bin.stable.latest.default;
+          msrv = mkDevShell pkgs.rust-bin.stable.${msrv}.default;
         };
-      in
-      {
-        devShells.default = mkDevShell pkgs.rust-bin.stable.latest.default;
-        devShells.msrv = mkDevShell pkgs.rust-bin.stable.${msrv}.default;
         packages.default = mkPackage pkgs.rust-bin.stable.latest.minimal;
-      }
-    );
+      };
+    };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,24 @@
+{
+  self',
+  packageToml,
+  rust-bin,
+  mkShell,
+}: let
+  msrv = packageToml.rust-version;
+
+  mkDevShell = rust:
+    mkShell {
+      inputsFrom = [
+        (self'.packages.default.override {
+          rust = rust.override {
+            extensions = ["rust-src"];
+          };
+        })
+      ];
+
+      env.RUST_BACKTRACE = 1;
+    };
+in {
+  default = mkDevShell rust-bin.stable.latest.default;
+  msrv = mkDevShell rust-bin.stable.${msrv}.default;
+}


### PR DESCRIPTION
This PR refactors the recently added flake:

1. Added shell.nix and default.nix for users that don't use flakes and use Nix2
2. Removed flake-utils and used flake-parts instead, it's way less volatile and has a couple of nice features that could come in handy later (e.g. debugging, really nice modularization)
3. Changed up a few things to comply with best practices and conventions - like attribute names (`nativeBuildInputs` vs `packages` for `mkShell`), name conventions (`pname`, `name`, `version` for mkDerivation), etc.
4. Made the source of the derivation reproducible when built locally (`src = ./.` relies on the current folder name, which if changed can trigger cache misses)
5. The `default.nix` and `shell.nix` are `callPackage`d, which automatically fills their arguments with `nixpkgs` packages and allows for easy overriding
6. Split the package's dependencies into correct categories, in this case only 3 matter:
	- `nativeBuildInputs` - dependencies which are only needed in the build process and nowhere else (like build tools).
	- `buildInputs` - dependencies which will be needed by runtime later - static libraries linked into the library, dynamic libraries and such.
	- `nativeCheckInputs` - native dependencies for tests, this one has a separate category because one may wish to disable checks for the package which would also make the derivation not pull in the unnecessary dependencies.

	For more info on that matter see - https://nixos.org/manual/nixpkgs/stable/#ssec-stdenv-dependencies


As for the modularization - if you'd like the flake could also be split into actual modules, which would make the flake [look something like this](https://github.com/Dich0tomy/Dire/blob/trunk/flake.nix) and then [subsequent modules something like this](https://github.com/Dich0tomy/Dire/tree/trunk/nix).

As for maintenance of the package - changes are required if you add Rust libraries that depend on system installed libraries as well or add any kind of resources that would need to be installed into the system later (like man docs, shell completions, icons) - I'm happy to assist with that.