### PR TITLE
Add support for play -r.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,6 +124,10 @@ pub struct Play {
     /// Automatically pause on markers
     #[arg(short = 'm', long)]
     pub pause_on_markers: bool,
+
+    /// Resize terminal window with control sequences.
+    #[arg(short = 'r', long)]
+    pub resize: bool,
 }
 
 #[derive(Debug, Args)]

--- a/src/cmd/play.rs
+++ b/src/cmd/play.rs
@@ -30,6 +30,7 @@ impl cli::Play {
                 idle_time_limit,
                 self.pause_on_markers,
                 &keys,
+                self.resize,
             )?;
 
             if !self.loop_ || !ended {


### PR DESCRIPTION
The new `-r` or `--resize` option causes asciinema to send `CSI 8 ; <width> ; <height> t` for `r` commands in the Asciicast. This causes the terminal window to resize as it did during the recording. This commit also sets the initial size. Doing so causes recordings of interactive programs to render properly.

Resizing is off by default for backward compatibility.

I see this [was discussed](https://github.com/asciinema/asciinema/issues/198) previously but as far as I can tell it was closed without being implemented.