### PR TITLE
Add option to include custom HTML into <head> when streaming with --serve

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -36,6 +36,9 @@
       box-shadow: color-mix(in oklab, var(--term-color-background) 50%, black) 0px 0px 60px 5px;
     }
   </style>
+
+  {{{html_head}}}
+
 </head>
 <body>
   <script src="asciinema-player.min.js"></script>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -141,6 +141,11 @@ pub struct Stream {
     #[arg(short, long, value_name = "IP:PORT", default_missing_value = DEFAULT_LISTEN_ADDR, num_args = 0..=1)]
     pub serve: Option<SocketAddr>,
 
+    /// Additional content to include in the HTML head in case of streaming with built-in HTTP
+    /// server
+    #[arg(short = 'H', long, value_name = " <style> * { font-family: monospace; } </style> ", num_args = 0..=1)]
+    pub html_head: Option<String>,
+
     /// Relay the stream via an asciinema server
     #[arg(short, long, value_name = "STREAM-ID|WS-URL", default_missing_value = "", num_args = 0..=1, value_parser = validate_forward_target)]
     pub relay: Option<RelayTarget>,

--- a/src/cmd/stream.rs
+++ b/src/cmd/stream.rs
@@ -80,6 +80,7 @@ impl Command for cli::Stream {
                 record_input,
                 keys,
                 notifier,
+                self.html_head.clone(),
             );
 
             self.init_logging()?;

--- a/src/streamer/mod.rs
+++ b/src/streamer/mod.rs
@@ -23,6 +23,7 @@ pub struct Streamer {
     prefix_mode: bool,
     listener: Option<net::TcpListener>,
     forward_url: Option<url::Url>,
+    html_head: Option<String>,
     // XXX: field (drop) order below is crucial for correct shutdown
     pty_tx: mpsc::UnboundedSender<Event>,
     notifier_tx: std::sync::mpsc::Sender<String>,
@@ -44,6 +45,7 @@ impl Streamer {
         record_input: bool,
         keys: KeyBindings,
         notifier: Box<dyn Notifier>,
+        html_head: Option<String>,
     ) -> Self {
         let (notifier_tx, notifier_rx) = std::sync::mpsc::channel();
         let (pty_tx, pty_rx) = mpsc::unbounded_channel();
@@ -62,6 +64,7 @@ impl Streamer {
             prefix_mode: false,
             listener,
             forward_url,
+            html_head,
         }
     }
 
@@ -91,6 +94,7 @@ impl pty::Handler for Streamer {
                 listener,
                 clients_tx.clone(),
                 shutdown_token.clone(),
+                self.html_head.clone(),
             ))
         });
 


### PR DESCRIPTION
This adds a CLI arg into `asciinema stream`:

```
  -H, --html-head [< <style> * { font-family: monospace; } </style> >]
          Additional content to include in the HTML head in case of streaming with built-in HTTP server
```

Use-case is to allow quickly add customizations. For example adding custom fonts (e.g. Nerd Fonts):

```
asciinema stream -s 0.0.0.0:8080 -H '<style>
  @import url(https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/firacode-nerd-font.css);
  * {
    font-family: "FiraCode Nerd Font", monospace;
  }
  </style>'
```

Results in: 

https://asciinema.org/a/2vUX3OJVwCjpNEgArf0IhQnj8

![image](https://github.com/user-attachments/assets/47f992e6-645a-4180-9755-03df0844e533)

Resolve #670 

