### PR TITLE
Support unix sockets output

### DIFF
--- a/src/asciicast.rs
+++ b/src/asciicast.rs
@@ -30,6 +30,7 @@ pub struct Header {
     pub command: Option<String>,
     pub title: Option<String>,
     pub env: Option<HashMap<String, String>>,
+    #[allow(dead_code)]
     pub child_pid: Option<u32>,
 }
 

--- a/src/asciicast/v1.rs
+++ b/src/asciicast/v1.rs
@@ -48,13 +48,14 @@ pub fn load(json: String) -> Result<Asciicast<'static>> {
         command: asciicast.command.clone(),
         title: asciicast.title.clone(),
         env: asciicast.env.clone(),
+        child_pid: None,
     };
 
     let events = Box::new(
         asciicast
             .stdout
             .into_iter()
-            .map(|e| Ok(Event::output(e.time, e.data))),
+            .map(|e| Ok(Event::output(e.time, e.data, None))),
     );
 
     Ok(Asciicast { header, events })

--- a/src/asciicast/v2.rs
+++ b/src/asciicast/v2.rs
@@ -83,6 +83,7 @@ impl Parser {
             command: self.0.command.clone(),
             title: self.0.title.clone(),
             env: self.0.env.clone(),
+            child_pid: None,
         };
 
         let events = Box::new(lines.filter_map(parse_line));
@@ -137,6 +138,7 @@ fn parse_event(line: String) -> Result<Event> {
     Ok(Event {
         time: event.time,
         data,
+        child_pid: None,
     })
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -226,6 +226,10 @@ pub struct Session {
     /// Log file path
     #[arg(long)]
     pub log_file: Option<PathBuf>,
+
+    /// Unix domain socket path for  proxy (hidden, internal use only)
+    #[arg(long, hide = true)]
+    pub socket_path: Option<String>,
 }
 
 #[derive(Debug, Args)]

--- a/src/cmd/session.rs
+++ b/src/cmd/session.rs
@@ -139,8 +139,8 @@ impl cli::Session {
         // If socket_path is set, use SocketWriterStarter and suppress all logs and file outputs
         if let Some(socket_path) = &self.socket_path {
             let format = self.format.unwrap_or(Format::AsciicastV3);
-            let socket_term_type = self.get_term_type();
-            let socket_term_version = self.get_term_version()?;
+            let _socket_term_type = self.get_term_type();
+            let _socket_term_version = self.get_term_version()?;
             let encoder: Box<dyn crate::encoder::Encoder + Send> = match format {
                 Format::AsciicastV3 => Box::new(AsciicastV3Encoder::new(false)),
                 Format::AsciicastV2 => Box::new(AsciicastV2Encoder::new(false, 0)),
@@ -148,8 +148,8 @@ impl cli::Session {
                 Format::Txt => Box::new(TextEncoder::new()),
             };
             let metadata = SocketMetadata {
-                term_type: socket_term_type,
-                term_version: socket_term_version,
+                term_type: _socket_term_type,
+                term_version: _socket_term_version,
                 idle_time_limit: self.idle_time_limit.or(cmd_config.idle_time_limit),
                 command: self.get_command(cmd_config),
                 title: self.title.clone(),
@@ -164,8 +164,8 @@ impl cli::Session {
             };
             outputs.push(Box::new(socket_writer));
         } else {
-            let term_type = self.get_term_type();
-            let term_version = self.get_term_version()?;
+            let _term_type = self.get_term_type();
+            let _term_version = self.get_term_version()?;
             if server.is_some() || forwarder.is_some() {
                 let output = stream.start(runtime.handle().clone());
                 outputs.push(Box::new(output));

--- a/src/encoder/raw.rs
+++ b/src/encoder/raw.rs
@@ -45,24 +45,25 @@ mod tests {
         let header = Header {
             term_cols: 100,
             term_rows: 50,
+            child_pid: None,
             ..Default::default()
         };
 
         assert_eq!(enc.header(&header), "\x1b[8;50;100t".as_bytes());
 
         assert_eq!(
-            enc.event(Event::output(0, "he\x1b[1mllo\r\n".to_owned())),
+            enc.event(Event::output(0, "he\x1b[1mllo\r\n".to_owned(), None)),
             "he\x1b[1mllo\r\n".as_bytes()
         );
 
         assert_eq!(
-            enc.event(Event::output(1, "world\r\n".to_owned())),
+            enc.event(Event::output(1, "world\r\n".to_owned(), None)),
             "world\r\n".as_bytes()
         );
 
-        assert!(enc.event(Event::input(2, ".".to_owned())).is_empty());
-        assert!(enc.event(Event::resize(3, (80, 24))).is_empty());
-        assert!(enc.event(Event::marker(4, ".".to_owned())).is_empty());
+        assert!(enc.event(Event::input(2, ".".to_owned(), None)).is_empty());
+        assert!(enc.event(Event::resize(3, (80, 24), None)).is_empty());
+        assert!(enc.event(Event::marker(4, ".".to_owned(), None)).is_empty());
         assert!(enc.flush().is_empty());
     }
 }

--- a/src/encoder/txt.rs
+++ b/src/encoder/txt.rs
@@ -65,17 +65,18 @@ mod tests {
         let header = Header {
             term_cols: 3,
             term_rows: 1,
+            child_pid: None,
             ..Default::default()
         };
 
         assert!(enc.header(&header).is_empty());
 
         assert!(enc
-            .event(Event::output(0, "he\x1b[1mllo\r\n".to_owned()))
+            .event(Event::output(0, "he\x1b[1mllo\r\n".to_owned(), None))
             .is_empty());
 
         assert!(enc
-            .event(Event::output(1, "world\r\n".to_owned()))
+            .event(Event::output(1, "world\r\n".to_owned(), None))
             .is_empty());
 
         assert_eq!(enc.flush(), "hello\nworld\n".as_bytes());

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -50,6 +50,7 @@ impl session::OutputStarter for FileWriterStarter {
             command: self.metadata.command.as_ref().cloned(),
             title: self.metadata.title.as_ref().cloned(),
             env: self.metadata.env.as_ref().cloned(),
+            child_pid: None,
         };
 
         if let Err(e) = self.writer.write_all(&self.encoder.header(&header)) {
@@ -91,12 +92,11 @@ impl session::Output for FileWriter {
 impl From<session::Event> for asciicast::Event {
     fn from(event: session::Event) -> Self {
         match event {
-            session::Event::Output(time, text) => asciicast::Event::output(time, text),
-            session::Event::Input(time, text) => asciicast::Event::input(time, text),
-            session::Event::Resize(time, tty_size) => {
-                asciicast::Event::resize(time, tty_size.into())
-            }
-            session::Event::Marker(time, label) => asciicast::Event::marker(time, label),
+            session::Event::Output(time, text, pid) => asciicast::Event::output(time, text, pid),
+            session::Event::Input(time, text, pid) => asciicast::Event::input(time, text, pid),
+            session::Event::Resize(time, tty_size, pid) =>
+                asciicast::Event::resize(time, tty_size.into(), pid),
+            session::Event::Marker(time, label, pid) => asciicast::Event::marker(time, label, pid),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod status;
 mod stream;
 mod tty;
 mod util;
+mod socket_writer;
 
 use clap::Parser;
 
@@ -53,6 +54,7 @@ fn main() -> anyhow::Result<()> {
                 serve: None,
                 relay: None,
                 log_file: None,
+                socket_path: None,
             };
 
             cmd.run(&config, &config.cmd_rec())
@@ -75,6 +77,7 @@ fn main() -> anyhow::Result<()> {
                 serve: stream.serve,
                 relay: stream.relay,
                 log_file: stream.log_file,
+                socket_path: None,
             };
 
             cmd.run(&config, &config.cmd_stream())

--- a/src/player.rs
+++ b/src/player.rs
@@ -42,7 +42,7 @@ pub fn play(
     let mut pause_elapsed_time: Option<u64> = None;
     let mut next_event = events.next().transpose()?;
 
-    while let Some(Event { time, data }) = &next_event {
+    while let Some(Event { time, data, .. }) = &next_event {
         if let Some(pet) = pause_elapsed_time {
             if let Some(input) = read_input(&mut tty, 1_000_000)? {
                 if keys.quit.as_ref().is_some_and(|k| k == &input) {
@@ -63,7 +63,7 @@ pub fn play(
 
                     next_event = events.next().transpose()?;
                 } else if keys.next_marker.as_ref().is_some_and(|k| k == &input) {
-                    while let Some(Event { time, data }) = next_event {
+                    while let Some(Event { time, data, .. }) = next_event {
                         next_event = events.next().transpose()?;
 
                         match data {
@@ -84,7 +84,7 @@ pub fn play(
                 }
             }
         } else {
-            while let Some(Event { time, data }) = &next_event {
+            while let Some(Event { time, data, .. }) = &next_event {
                 let delay = *time as i64 - epoch.elapsed().as_micros() as i64;
 
                 if delay > 0 {

--- a/src/socket_writer.rs
+++ b/src/socket_writer.rs
@@ -1,0 +1,109 @@
+use std::collections::HashMap;
+use std::io;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::net::UnixStream;
+use tokio::runtime::Handle;
+use tokio::sync::Mutex;
+use tokio::io::AsyncWriteExt;
+
+use crate::asciicast;
+use crate::encoder;
+use crate::notifier::Notifier;
+use crate::session;
+use crate::tty::{TtySize, TtyTheme};
+
+pub struct SocketWriterStarter {
+    pub socket_path: String,
+    pub encoder: Box<dyn encoder::Encoder + Send>,
+    pub metadata: Metadata,
+    pub notifier: Box<dyn Notifier>,
+    pub handle: Handle,
+}
+
+pub struct SocketWriter {
+    stream: Arc<Mutex<UnixStream>>,
+    encoder: Box<dyn encoder::Encoder + Send>,
+    notifier: Box<dyn Notifier>,
+}
+
+pub struct Metadata {
+    pub term_type: Option<String>,
+    pub term_version: Option<String>,
+    pub idle_time_limit: Option<f64>,
+    pub command: Option<String>,
+    pub title: Option<String>,
+    pub env: Option<HashMap<String, String>>,
+}
+
+impl session::OutputStarter for SocketWriterStarter {
+    fn start(
+        mut self: Box<Self>,
+        time: SystemTime,
+        tty_size: TtySize,
+        theme: Option<TtyTheme>,
+    ) -> io::Result<Box<dyn session::Output>> {
+        let timestamp = time.duration_since(UNIX_EPOCH).unwrap().as_secs();
+        let header = asciicast::Header {
+            term_cols: tty_size.0,
+            term_rows: tty_size.1,
+            term_type: self.metadata.term_type,
+            term_version: self.metadata.term_version,
+            term_theme: theme,
+            timestamp: Some(timestamp),
+            idle_time_limit: self.metadata.idle_time_limit,
+            command: self.metadata.command.as_ref().cloned(),
+            title: self.metadata.title.as_ref().cloned(),
+            env: self.metadata.env.as_ref().cloned(),
+        };
+        let mut encoder = self.encoder;
+        let mut notifier = self.notifier;
+        let socket_path = self.socket_path.clone();
+        let handle = self.handle.clone();
+        let header_bytes = encoder.header(&header);
+        let fut = async move {
+            let stream = UnixStream::connect(socket_path).await;
+            match stream {
+                Ok(mut stream) => {
+                    if let Err(e) = stream.write_all(&header_bytes).await {
+                        let _ = notifier.notify("Socket write error, session won't be recorded".to_owned());
+                        return Err(io::Error::new(io::ErrorKind::Other, e));
+                    }
+                    Ok(Box::new(SocketWriter {
+                        stream: Arc::new(Mutex::new(stream)),
+                        encoder,
+                        notifier,
+                    }) as Box<dyn session::Output>)
+                }
+                Err(e) => {
+                    let _ = notifier.notify("Socket connect error, session won't be recorded".to_owned());
+                    Err(io::Error::new(io::ErrorKind::Other, e))
+                }
+            }
+        };
+        handle.block_on(fut)
+    }
+}
+
+impl session::Output for SocketWriter {
+    fn event(&mut self, event: session::Event) -> io::Result<()> {
+        let bytes = self.encoder.event(event.into());
+        let stream = self.stream.clone();
+        let fut = async move {
+            let mut stream = stream.lock().await;
+            stream.write_all(&bytes).await
+        };
+        tokio::runtime::Handle::current().block_on(fut)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let bytes = self.encoder.flush();
+        let stream = self.stream.clone();
+        let fut = async move {
+            let mut stream = stream.lock().await;
+            stream.write_all(&bytes).await
+        };
+        tokio::runtime::Handle::current().block_on(fut)
+    }
+} 

--- a/src/socket_writer.rs
+++ b/src/socket_writer.rs
@@ -26,6 +26,7 @@ pub struct SocketWriter {
     stream: Arc<Mutex<UnixStream>>,
     encoder: Box<dyn encoder::Encoder + Send>,
     notifier: Box<dyn Notifier>,
+    handle: Handle,
 }
 
 pub struct Metadata {
@@ -74,6 +75,7 @@ impl session::OutputStarter for SocketWriterStarter {
                         stream: Arc::new(Mutex::new(stream)),
                         encoder,
                         notifier,
+                        handle,
                     }) as Box<dyn session::Output>)
                 }
                 Err(e) => {
@@ -82,7 +84,7 @@ impl session::OutputStarter for SocketWriterStarter {
                 }
             }
         };
-        handle.block_on(fut)
+        self.handle.block_on(fut)
     }
 }
 
@@ -94,7 +96,7 @@ impl session::Output for SocketWriter {
             let mut stream = stream.lock().await;
             stream.write_all(&bytes).await
         };
-        tokio::runtime::Handle::current().block_on(fut)
+        self.handle.block_on(fut)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -104,6 +106,6 @@ impl session::Output for SocketWriter {
             let mut stream = stream.lock().await;
             stream.write_all(&bytes).await
         };
-        tokio::runtime::Handle::current().block_on(fut)
+        self.handle.block_on(fut)
     }
 } 

--- a/src/socket_writer.rs
+++ b/src/socket_writer.rs
@@ -25,6 +25,7 @@ pub struct SocketWriterStarter {
 pub struct SocketWriter {
     stream: Arc<Mutex<UnixStream>>,
     encoder: Box<dyn encoder::Encoder + Send>,
+    #[allow(dead_code)]
     notifier: Box<dyn Notifier>,
     handle: Handle,
 }
@@ -40,7 +41,7 @@ pub struct Metadata {
 
 impl session::OutputStarter for SocketWriterStarter {
     fn start(
-        mut self: Box<Self>,
+        self: Box<Self>,
         time: SystemTime,
         tty_size: TtySize,
         theme: Option<TtyTheme>,

--- a/src/socket_writer.rs
+++ b/src/socket_writer.rs
@@ -57,6 +57,7 @@ impl session::OutputStarter for SocketWriterStarter {
             command: self.metadata.command.as_ref().cloned(),
             title: self.metadata.title.as_ref().cloned(),
             env: self.metadata.env.as_ref().cloned(),
+            child_pid: None,
         };
         let mut encoder = self.encoder;
         let mut notifier = self.notifier;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -90,24 +90,24 @@ async fn run(
                         last_event_id += 1;
 
                         match event {
-                            session::Event::Output(time, text) => {
+                            session::Event::Output(time, text, _) => {
                                 vt.feed_str(&text);
                                 let _ = broadcast_tx.send(Event::Output(last_event_id, time, text));
                                 stream_time = time;
                             }
 
-                            session::Event::Input(time, text) => {
+                            session::Event::Input(time, text, _) => {
                                 let _ = broadcast_tx.send(Event::Input(last_event_id, time, text));
                                 stream_time = time;
                             }
 
-                            session::Event::Resize(time, tty_size) => {
+                            session::Event::Resize(time, tty_size, _) => {
                                 vt.resize(tty_size.0.into(), tty_size.1.into());
                                 let _ = broadcast_tx.send(Event::Resize(last_event_id, time, tty_size));
                                 stream_time = time;
                             }
 
-                            session::Event::Marker(time, label) => {
+                            session::Event::Marker(time, label, _) => {
                                 let _ = broadcast_tx.send(Event::Marker(last_event_id, time, label));
                                 stream_time = time;
                             }


### PR DESCRIPTION
Changes are optimized for current use case

May not want to add a terminal PID to the .cast event format, but it's key for me ingesting multiple terminals on a single socket.