### PR TITLE
Add filename of cast file to session end output

### DIFF
--- a/src/cmd/session.rs
+++ b/src/cmd/session.rs
@@ -152,7 +152,12 @@ impl cli::Session {
             .await?
         };
 
-        status::info!("asciinema session ended");
+        if let Some(path) = self.output_file.as_ref() {
+            status::info!("asciinema session ended");
+            status::info!("Recorded to {}", path);
+        } else {
+            status::info!("asciinema session ended");
+        }
         shutdown_token.cancel();
 
         if let Some(task) = server {


### PR DESCRIPTION
As discussed in #680 this adds some additional information to the output generated after asciinema exits.

Feel free to reject this PR if this do not want to add or update this part of the code.
But if you like the general idea but this needs changes, let me know.
