### PR TITLE
Require at least one of -l / -r for session command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -308,7 +308,7 @@ pub struct Stream {
 }
 
 #[derive(Debug, Args)]
-#[clap(group(ArgGroup::new("mode").args(&["stream_local", "stream_remote"]).multiple(true).required(true)))]
+#[clap(group(ArgGroup::new("mode").args(&["output_file", "stream_local", "stream_remote"]).multiple(true).required(true)))]
 pub struct Session {
     /// Save the session to a file at the specified path. Can be combined with local and remote streaming.
     #[arg(


### PR DESCRIPTION
As of right now I didn't include the options `-o / --output` as one of the required sets of args.
I remember you saying that `asciinema session` is a mix of `record` and `stream`, but I understood it being more "stream" than recording so I didn't add it as one of the required args.

Hence the draft PR

This fixes #689