### PR TITLE
allow playing a cast from stdin

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -320,7 +320,7 @@ pub struct Record {
 
 #[derive(Debug, Args)]
 pub struct Play {
-    /// The path to an asciicast file or HTTP(S) URL to play back. HTTP(S) URLs allow playing recordings directly from the web without need for manual downloading. Supported formats include asciicast v1, v2, and v3.
+    /// The path to an asciicast file or HTTP(S) URL to play back. Can be a local file path, HTTP(S) URL for remote files, or '-' to read from standard input. Remote URLs allow playing recordings directly from the web without need for manual downloading. Supported formats include asciicast v1, v2, and v3.
     pub file: String,
 
     /// Control the playback speed as a multiplier of the original timing. Values greater than 1.0 make playback faster, while values less than 1.0 make it slower. For example, --speed 2.0 plays at double speed, while --speed 0.5 plays at half speed. The default is 1.0 (original speed). Can also be set via the config file option playback.speed.

--- a/src/cmd/play.rs
+++ b/src/cmd/play.rs
@@ -12,7 +12,11 @@ impl cli::Play {
         let config = Config::new(None)?;
         let speed = self.speed.or(config.playback.speed).unwrap_or(1.0);
         let idle_time_limit = self.idle_time_limit.or(config.playback.idle_time_limit);
-        let path = util::get_local_path(&self.file)?;
+        let path: Box<dyn AsRef<std::path::Path>> = if self.file == "-" {
+            Box::new(std::path::Path::new("/dev/stdin"))
+        } else {
+            util::get_local_path(&self.file)?
+        };
         let keys = get_key_bindings(&config.playback)?;
         let runtime = Runtime::new()?;
 


### PR DESCRIPTION
Using same code as convert uses for `INPUT`, allow playing a cast from stdin.

Personally, quite useful for longer casts that I have gzipped:
`zcat my.cast.gz | asciinema play -`