### PR TITLE
allow `play` to stream events

### DIFF
--- a/src/asciicast/v2.rs
+++ b/src/asciicast/v2.rs
@@ -69,7 +69,10 @@ pub fn open(header_line: &str) -> Result<Parser> {
 }
 
 impl Parser {
-    pub fn parse<'a, I: Iterator<Item = io::Result<String>> + Send + 'a>(self, lines: I) -> Asciicast<'a> {
+    pub fn parse<'a, I: Iterator<Item = io::Result<String>> + Send + 'a>(
+        self,
+        lines: I,
+    ) -> Asciicast<'a> {
         let term_type = self
             .0
             .env

--- a/src/asciicast/v2.rs
+++ b/src/asciicast/v2.rs
@@ -69,7 +69,7 @@ pub fn open(header_line: &str) -> Result<Parser> {
 }
 
 impl Parser {
-    pub fn parse<'a, I: Iterator<Item = io::Result<String>> + 'a>(self, lines: I) -> Asciicast<'a> {
+    pub fn parse<'a, I: Iterator<Item = io::Result<String>> + Send + 'a>(self, lines: I) -> Asciicast<'a> {
         let term_type = self
             .0
             .env

--- a/src/asciicast/v3.rs
+++ b/src/asciicast/v3.rs
@@ -85,7 +85,7 @@ pub fn open(header_line: &str) -> Result<Parser> {
 }
 
 impl Parser {
-    pub fn parse<'a, I: Iterator<Item = io::Result<String>> + 'a>(
+    pub fn parse<'a, I: Iterator<Item = io::Result<String>> + Send + 'a>(
         mut self,
         lines: I,
     ) -> Asciicast<'a> {

--- a/src/player.rs
+++ b/src/player.rs
@@ -162,13 +162,11 @@ fn emit_session_events(
 
     let events = asciicast::limit_idle_time(recording.events, idle_time_limit);
     let events = asciicast::accelerate(events, speed);
-    // TODO avoid collect, support playback from stdin
-    let events: Vec<_> = events.collect();
     let (tx, rx) = mpsc::channel::<Result<Event>>(1024);
 
-    tokio::spawn(async move {
+    tokio::task::spawn_blocking(move || {
         for event in events {
-            if tx.send(event).await.is_err() {
+            if tx.blocking_send(event).is_err() {
                 break;
             }
         }


### PR DESCRIPTION
This change removes the memory bottleneck in the play command by streaming events from disk instead of loading them all into memory.

This is greatly assisted by Claude but after a long chat around the existing `.collect` and its motivation.

Changes:
- Replace tokio::spawn with tokio::task::spawn_blocking in emit_session_events()
- Remove .collect() that was loading all events into a Vec
- Use blocking_send() instead of async send() for the channel

Benefits:
- Memory usage reduced
- Instant playback start (no pre-loading delay)
- Support for arbitrarily large recordings
- Foundation for stdin streaming support (cat file.cast | asciinema play -)

Technical details:
The original code used .collect() because tokio::spawn requires 'static lifetime. By using spawn_blocking instead, we can stream the iterator directly since blocking tasks don't have the same lifetime constraints. File I/O is blocking anyway, so this is the correct approach.

Testing:
- Generated different large files and compared Max RSS between develop version and my branch
- ```./ gtime -v ./asciinema-original play --speed 10000 size_100.cast
        Maximum resident set size (kbytes): 221712
        ./ gtime -v ./asciinema-new play --speed 10000 size_100.cast
        Maximum resident set size (kbytes): 111120
        ./ gtime -v ./asciinema-original play --speed 10000 size_500.cast
        Maximum resident set size (kbytes): 924512
        ./ gtime -v ./asciinema-new play --speed 10000 size_500.cast
        Maximum resident set size (kbytes): 508768
        ./ gtime -v ./asciinema-original play --speed 10000 size_2000.cast
        Maximum resident set size (kbytes): 2003312
        ./ gtime -v ./asciinema-new play --speed 10000 size_2000.cast
        Maximum resident set size (kbytes): 701328
   ```
- As this is Max RSS it, the increased memory is likely from the OS and not the binary but it still shows a much friendlier scaling of memory usage for the input file :smile: