### PR TITLE
Nix package improvement

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,32 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "lastModified": 1779357205,
+        "narHash": "sha256-cCO8aTqss5x9Ky8GWkpY0Hy5fyTZEbtifSUV8QjSzic=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "f83fc3c307e74bc5fd5adb7eb6b8b13ffd2a36e1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -59,14 +43,16 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1772334676,
-        "narHash": "sha256-Jrc0J3AH+iNJDlUze3+FJZv2R0BZnhANFnD52V4kyvI=",
+        "lastModified": 1779506148,
+        "narHash": "sha256-OffE5yuMrSW71zIJNLvtl9MCO6WTAHEjlFPUCvkd/QM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9879be11f30fd3bbf848e653a7f991549e8973b5",
+        "rev": "d9973e2ab49747fada06ebbe26cda27eb0220cf1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -22,7 +23,7 @@
           overlays = [ (import rust-overlay) ];
         };
 
-        packageToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package;
+        packageToml = (fromTOML (builtins.readFile ./Cargo.toml)).package;
         msrv = packageToml.rust-version;
       in
       {


### PR DESCRIPTION
## Flatten nixpkgs dependencies

- Use our nixpkgs instead of rust-overlay's, so we don't need to fetch nixpkgs twice.
- The `builtin` part in `builtin.fromTOML` is unnecessary according to the `nixf` linter:

  ```
  this is a prelude builtin, the `builtins.` prefix can be
  removed (fix available) (nixf sema-primop-removed-prefix)
  ```

Dogfood result:

```
$ nix flake update
• Updated input 'asciinema':
    'github:asciinema/asciinema/42413b2' (2026-05-12)
  → 'github:pan93412/asciinema/5ec999b' (2026-05-23)
• Updated input 'asciinema/rust-overlay':
    'github:oxalica/rust-overlay/9879be1' (2026-03-01)
  → 'github:oxalica/rust-overlay/d9973e2' (2026-05-23)
• Updated input 'asciinema/rust-overlay/nixpkgs':
    'github:NixOS/nixpkgs/18dd725' (2025-04-13)
  → follows 'asciinema/nixpkgs'
```

## Use lib.optionals for buildInputs

`lib.optional` generates an array containing the value:

    optional :: Bool -> a -> [a]

This introduces the following warning:

    evaluation warning: Dependency of package 'asciinema'
    uses a nested list in attribute 'buildInputs'. This is
    deprecated as of Nixpkgs release 26.05, and support will
    be removed in a future nixpkgs release.

I fixed it by using the correct `lib.optionals`, whose signature is:

    optionals :: Bool -> [a] -> [a]

Exactly what we want.

Fixed #746 

Dogfood result:

```
$ nix --version
nix (Determinate Nix 3.19.1) 2.34.6

$ nix build . --no-link
```

(no warnings)