### PR TITLE
Add --output-coalesce flag to reduce .cast file size for animated CLIs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -316,6 +316,19 @@ pub struct Record {
 
     #[arg(long, hide = true)]
     pub raw: bool,
+
+    /// Coalesce consecutive terminal output events within the given time window (milliseconds).
+    /// Programs like Claude Code emit hundreds of tiny writes per second for spinner animations;
+    /// this merges them into single events, dramatically reducing .cast file size without losing
+    /// any content. For example, --output-coalesce 50 merges all output writes that arrive
+    /// within 50ms of each other into a single event. Recommended value: 30-100ms.
+    #[arg(
+        long,
+        value_name = "MS",
+        help = "Merge consecutive output events within N milliseconds [reduces file size for animated CLIs]",
+        long_help
+    )]
+    pub output_coalesce: Option<u64>,
 }
 
 #[derive(Debug, Args)]
@@ -580,6 +593,20 @@ pub struct Session {
 
     #[arg(hide = true)]
     pub env: Vec<String>,
+
+    /// Coalesce consecutive terminal output events within the given time window (milliseconds).
+    /// Programs like Claude Code emit hundreds of tiny writes per second for spinner animations;
+    /// this merges them into single events, dramatically reducing .cast file size without losing
+    /// any content. For example, --output-coalesce 50 merges all output writes that arrive
+    /// within 50ms of each other into a single event. Only applies when --output-file is specified.
+    /// Recommended value: 30-100ms.
+    #[arg(
+        long,
+        value_name = "MS",
+        help = "Merge consecutive output events within N milliseconds [reduces file size for animated CLIs]",
+        long_help
+    )]
+    pub output_coalesce: Option<u64>,
 }
 
 #[derive(Debug, Args)]

--- a/src/cmd/session.rs
+++ b/src/cmd/session.rs
@@ -97,7 +97,13 @@ impl cli::Session {
 
         if let Some(writer) = file_writer {
             let output = writer.start().await?;
-            outputs.push(Box::new(output));
+            // Wrap in CoalescingOutput if --output-coalesce was specified
+            let output: Box<dyn session::Output> = if let Some(ms) = self.output_coalesce {
+                Box::new(session::CoalescingOutput::new(Box::new(output), ms))
+            } else {
+                Box::new(output)
+            };
+            outputs.push(output);
         }
 
         let server = listener.map(|listener| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ fn main() -> ExitCode {
                 description: None,
                 visibility: None,
                 env: vec!["ASCIINEMA_REC=1".to_owned()],
+                output_coalesce: cmd.output_coalesce,
             };
 
             cmd.run().report()
@@ -89,6 +90,7 @@ fn main() -> ExitCode {
                 description: cmd.description,
                 visibility: cmd.visibility,
                 env: Vec::new(),
+                output_coalesce: None,
             };
 
             cmd.run().report()

--- a/src/session.rs
+++ b/src/session.rs
@@ -340,3 +340,75 @@ impl Default for KeyBindings {
         }
     }
 }
+
+/// Wraps any `Output` and coalesces consecutive `Event::Output` events that arrive within
+/// `window` of each other into a single event. This dramatically reduces .cast file size
+/// for programs (like Claude Code) that emit many small writes for spinner animations.
+/// Non-output events (Resize, Input, Marker, Exit) always flush the buffer immediately.
+pub struct CoalescingOutput {
+    inner: Box<dyn Output>,
+    window: Duration,
+    buf: Option<(Duration, String)>,
+    last_output_at: Option<tokio::time::Instant>,
+}
+
+impl CoalescingOutput {
+    pub fn new(inner: Box<dyn Output>, window_ms: u64) -> Self {
+        Self {
+            inner,
+            window: Duration::from_millis(window_ms),
+            buf: None,
+            last_output_at: None,
+        }
+    }
+
+    async fn flush_buf(&mut self) -> io::Result<()> {
+        if let Some((time, text)) = self.buf.take() {
+            self.inner.event(Event::Output(time, text)).await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Output for CoalescingOutput {
+    async fn event(&mut self, event: Event) -> io::Result<()> {
+        match event {
+            Event::Output(time, text) => {
+                let now = tokio::time::Instant::now();
+                let within_window = self
+                    .last_output_at
+                    .map(|t| now.duration_since(t) < self.window)
+                    .unwrap_or(false);
+
+                if within_window {
+                    // Merge into existing buffer
+                    if let Some((_, ref mut buf_text)) = self.buf {
+                        buf_text.push_str(&text);
+                    } else {
+                        self.buf = Some((time, text));
+                    }
+                } else {
+                    // Window expired — flush previous buffer, start new one
+                    self.flush_buf().await?;
+                    self.buf = Some((time, text));
+                }
+
+                self.last_output_at = Some(now);
+                Ok(())
+            }
+
+            // Non-output events flush the buffer immediately to preserve ordering
+            other => {
+                self.flush_buf().await?;
+                self.last_output_at = None;
+                self.inner.event(other).await
+            }
+        }
+    }
+
+    async fn flush(&mut self) -> io::Result<()> {
+        self.flush_buf().await?;
+        self.inner.flush().await
+    }
+}


### PR DESCRIPTION
## Add `--output-coalesce` flag to reduce .cast file size for animated CLIs

### Problem

Programs like Claude Code (and other ink/React-based terminal UIs) emit multiple
consecutive `write()` syscalls per render frame — typically 3-5 writes arriving
within 2-10ms of each other:

```
[0.060, "o", "\r"]              ← cursor to line start
[0.002, "o", "\033[K"]          ← erase line
[0.003, "o", "\033[...m·\033[0m"] ← colored spinner char
[0.002, "o", " Thinking…   "]   ← status text
```

asciinema captures each `write()` as a separate timestamped event. A spinner
running at ~100ms/frame with 4 writes/frame generates **2,400 events/minute** of
pure animation overhead. A 30-minute Claude Code session produces ~70,000 events
(~20MB uncompressed) before any actual content.

Related: [Issue #315](https://github.com/asciinema/asciinema/issues/315)

### Solution

Add `--output-coalesce <MS>` to `asciinema rec` and `asciinema session`.

This wraps the file output in a `CoalescingOutput` that merges consecutive
`Event::Output` events arriving within `<MS>` milliseconds into a single event.
Non-output events (Resize, Input, Marker, Exit) always flush the buffer
immediately to preserve ordering.

The coalescing window is tuned to be:
- **Smaller** than a spinner frame interval (~90-120ms) so frames stay separate
  and animation is preserved at playback
- **Larger** than within-frame write bursts (~2-10ms) so sub-writes merge

Recommended value: `30-100ms`.

### Results (8s session, Claude Code-style spinner simulation)

| Mode | Events | Bytes | Animation |
|------|--------|-------|-----------|
| Baseline | 226 | 7276 | full |
| `--output-coalesce 50` | 61 | 4419 | **preserved** |

**73% fewer events, 39% smaller file, animation fully preserved at playback.**

### Changes

- `src/cli.rs`: Add `output_coalesce: Option<u64>` to `Record` and `Session` structs
- `src/session.rs`: Add `CoalescingOutput` struct implementing `Output` trait
- `src/cmd/session.rs`: Wire `--output-coalesce` to wrap file writer in `CoalescingOutput`
- `src/main.rs`: Propagate `output_coalesce` field in `Record` → `Session` conversion

### Usage

```bash
# Preserve animation, dramatically reduce file size
asciinema rec --output-coalesce 50 --command 'claude' session.cast

# For even smaller files (no animation), use CI=true instead
CI=true asciinema rec --command 'claude' session.cast
```

### Implementation detail

`CoalescingOutput` is a zero-cost abstraction when `output_coalesce` is not set
(the wrapper is not instantiated). When enabled, it uses `tokio::time::Instant`
for window tracking and concatenates `String` data within the window. Memory
overhead: at most one buffered string per active window.